### PR TITLE
feature/array_native

### DIFF
--- a/autocti/clocker/two_d.py
+++ b/autocti/clocker/two_d.py
@@ -225,7 +225,7 @@ class Clocker2D(AbstractClocker):
         )
 
         try:
-            return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask).native
+            return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask, store_native=True)
         except AttributeError:
             return image_post_cti
 
@@ -323,7 +323,7 @@ class Clocker2D(AbstractClocker):
         )
 
         try:
-            return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask).native
+            return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask, store_native=True)
         except AttributeError:
             return image_post_cti
 
@@ -466,7 +466,7 @@ class Clocker2D(AbstractClocker):
                 image_post_cti[:, fast_column] = image_post_cti_pass[:, i]
 
         if cti.serial_trap_list is None:
-            return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask).native
+            return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask, store_native=True)
 
         serial_trap_list, serial_ccd = self._serial_traps_ccd_from(cti=cti)
 
@@ -489,7 +489,7 @@ class Clocker2D(AbstractClocker):
             verbosity=self.verbosity,
         )
 
-        return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask).native
+        return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask, store_native=True)
 
     def add_cti_serial_fast(
         self, data: aa.Array2D, cti: CTI2D, preloads: Preloads = Preloads()
@@ -564,7 +564,7 @@ class Clocker2D(AbstractClocker):
 
                 image_post_cti[fast_row, :] = image_post_cti_pass[i, :]
 
-        return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask).native
+        return aa.Array2D.manual_mask(array=image_post_cti, mask=data.mask, store_native=True)
 
     def remove_cti(self, data: aa.Array2D, cti: CTI2D) -> aa.Array2D:
         """
@@ -622,5 +622,5 @@ class Clocker2D(AbstractClocker):
         )
 
         return aa.Array2D.manual_mask(
-            array=image_cti_removed, mask=data.mask, header=data.header
-        ).native
+            array=image_cti_removed, mask=data.mask, header=data.header, store_native=True
+        )


### PR DESCRIPTION
By default, when an `Array2D` is input into a `manual` method in its `native` format (e.g. a 2D ndarray), it is mapped to its `slim` representation (e.g. a 1D `ndarray` consisting of all unmasked values).

In most use cases this process is very fast. However, in PyAutoCTI, the large quantity of data means this can become a bottleneck in the `log_likelihood_function`.

This feature adds an optional input which keeps the data in its `native` format, avoiding the slow mapping to a `slim` format.