### PR TITLE
Feature/noise normalization preload

### DIFF
--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -84,14 +84,32 @@ class AnalysisImagingCI(af.Analysis):
 
             if not os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
 
-                visualizer = VisualizerImaging(visualize_path=paths.image_path)
+                visualizer = VisualizerImagingCI(visualize_path=paths.image_path)
 
-                visualizer.visualize_imaging(imaging=self.imaging)
+                visualizer.visualize_imaging_ci(imaging_ci=self.dataset)
 
-                visualizer.visualize_hyper_images(
-                    hyper_galaxy_image_path_dict=self.hyper_galaxy_image_path_dict,
-                    hyper_model_image=self.hyper_model_image,
-                )
+                try:
+                    visualizer.visualize_imaging_ci_lines(
+                        imaging_ci=self.dataset, region="parallel_fpr"
+                    )
+                    visualizer.visualize_imaging_ci_lines(
+                        imaging_ci=self.dataset, region="parallel_eper"
+                    )
+
+                except (exc.RegionException, TypeError, ValueError):
+                    pass
+
+                try:
+                    visualizer.visualize_imaging_ci(imaging_ci=self.dataset)
+                    visualizer.visualize_imaging_ci_lines(
+                        imaging_ci=self.dataset, region="serial_fpr"
+                    )
+                    visualizer.visualize_imaging_ci_lines(
+                        imaging_ci=self.dataset, region="serial_eper"
+                    )
+
+                except (exc.RegionException, TypeError, ValueError):
+                    pass
 
             self.set_preloads(paths=paths, model=model)
 
@@ -168,16 +186,7 @@ class AnalysisImagingCI(af.Analysis):
 
         visualizer = VisualizerImagingCI(visualize_path=paths.image_path)
 
-        visualizer.visualize_imaging_ci(imaging_ci=self.dataset)
-
         try:
-            visualizer.visualize_imaging_ci_lines(
-                imaging_ci=self.dataset, region="parallel_fpr"
-            )
-            visualizer.visualize_imaging_ci_lines(
-                imaging_ci=self.dataset, region="parallel_eper"
-            )
-
             visualizer.visualize_fit_ci(fit=fit, during_analysis=during_analysis)
             visualizer.visualize_fit_ci_1d_lines(
                 fit=fit, during_analysis=during_analysis, region="parallel_fpr"
@@ -189,14 +198,6 @@ class AnalysisImagingCI(af.Analysis):
             pass
 
         try:
-            visualizer.visualize_imaging_ci(imaging_ci=self.dataset)
-            visualizer.visualize_imaging_ci_lines(
-                imaging_ci=self.dataset, region="serial_fpr"
-            )
-            visualizer.visualize_imaging_ci_lines(
-                imaging_ci=self.dataset, region="serial_eper"
-            )
-
             visualizer.visualize_fit_ci(fit=fit, during_analysis=during_analysis)
             visualizer.visualize_fit_ci_1d_lines(
                 fit=fit, during_analysis=during_analysis, region="serial_fpr"

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -1,5 +1,6 @@
 import os
 
+import autoarray as aa
 import autofit as af
 
 from autocti.charge_injection.imaging.imaging import ImagingCI
@@ -7,6 +8,7 @@ from autocti.charge_injection.fit import FitImagingCI
 from autocti.charge_injection.model.visualizer import VisualizerImagingCI
 from autocti.charge_injection.model.result import ResultImagingCI
 from autocti.clocker.two_d import Clocker2D
+from autocti.charge_injection.hyper import HyperCINoiseCollection
 from autocti.model.settings import SettingsCTI2D
 from autocti.preloads import Preloads
 
@@ -113,7 +115,13 @@ class AnalysisImagingCI(af.Analysis):
                 except (exc.RegionException, TypeError, ValueError):
                     pass
 
-            self.set_preloads(paths=paths, model=model)
+            #     if not model.has(HyperCINoiseCollection):
+
+            noise_normalization = aa.util.fit.noise_normalization_with_mask_from(
+                noise_map=self.dataset.noise_map, mask=self.dataset.mask
+            )
+
+            self.preloads.noise_normalization = noise_normalization
 
         return self
 

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -64,9 +64,13 @@ class AnalysisImagingCI(af.Analysis):
         PyAutoFit calls this function immediately before the non-linear search begins, therefore it can be used to
         perform tasks using the final model parameterization.
 
-        This function checks that the hyper-dataset is consistent with previous hyper-datasets if the model-fit is
-        being resumed from a previous run, and it visualizes objects which do not change throughout the model fit
-        like the dataset.
+        This function:
+
+         1) Visualizes the charge injection imaging dataset, which does not change during the analysis and thus can be
+         done once.
+
+         2) Checks if the noise-map is fixed (it is not if hyper functionality is on), and if it is fixed it
+         sets the noise-normalization to the preloads for computational speed.
 
         Parameters
         ----------
@@ -77,8 +81,6 @@ class AnalysisImagingCI(af.Analysis):
             The PyAutoFit model object, which includes model components representing the galaxies that are fitted to
             the imaging data.
         """
-
-        super().modify_before_fit(paths=paths, model=model)
 
         if not paths.is_complete:
 

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -170,6 +170,7 @@ class AnalysisImagingCI(af.Analysis):
             dataset=imaging_ci,
             post_cti_data=post_cti_data,
             hyper_noise_scalar_dict=hyper_noise_scalar_dict,
+            preloads=self.preloads
         )
 
     def fit_via_instance_from(

--- a/autocti/preloads.py
+++ b/autocti/preloads.py
@@ -9,6 +9,7 @@ class Preloads:
         parallel_fast_column_lists: Optional[np.ndarray] = None,
         serial_fast_index_list: Optional[np.ndarray] = None,
         serial_fast_row_lists: Optional[np.ndarray] = None,
+        noise_normalization: Optional[float] = None,
     ):
         """
         Class which offers a concise API for settings up the preloads, which before a model-fit are set up via
@@ -36,7 +37,10 @@ class Preloads:
             to arctic.
         serial_fast_row_lists
             The mapping of every repeated row in `serial_fast_index_list`  to all other rows which are identical.
-             This is used to map the reduced arCTIc output to the post-CTI data.
+            This is used to map the reduced arCTIc output to the post-CTI data.
+        noise_normalization
+            The noise normalization term of the log likelihood function evaluated in `Analysis` objects. If the
+            noise-map is fixed, this can be preloaded as it does not change.
 
         Returns
         -------
@@ -47,3 +51,4 @@ class Preloads:
         self.parallel_fast_column_lists = parallel_fast_column_lists
         self.serial_fast_index_list = serial_fast_index_list
         self.serial_fast_row_lists = serial_fast_row_lists
+        self.noise_normalization = noise_normalization

--- a/test_autocti/charge_injection/model/test_analysis_ci.py
+++ b/test_autocti/charge_injection/model/test_analysis_ci.py
@@ -7,11 +7,35 @@ from autofit.non_linear.mock.mock_search import MockSearch
 from autocti.charge_injection.model.result import ResultImagingCI
 
 
+def test__modify_before_fit__noise_normalization_preload(
+    imaging_ci_7x7, pre_cti_data_7x7, traps_x1, ccd, parallel_clocker_2d
+):
+
+    model = af.Collection(
+        cti=af.Model(ac.CTI2D, parallel_trap_list=traps_x1, parallel_ccd=ccd),
+    )
+
+    analysis = ac.AnalysisImagingCI(dataset=imaging_ci_7x7, clocker=parallel_clocker_2d)
+    analysis.modify_before_fit(paths=af.DirectoryPaths(), model=model)
+
+    assert analysis.preloads.noise_normalization == pytest.approx(157.984399, 1.0e-4)
+
+    model = af.Collection(
+        cti=af.Model(ac.CTI2D, parallel_trap_list=traps_x1, parallel_ccd=ccd),
+        hyper_noise=af.Model(ac.HyperCINoiseCollection),
+    )
+
+    analysis = ac.AnalysisImagingCI(dataset=imaging_ci_7x7, clocker=parallel_clocker_2d)
+    analysis.modify_before_fit(paths=af.DirectoryPaths(), model=model)
+
+    assert analysis.preloads.noise_normalization == None
+
+
 def test__make_result__result_imaging_is_returned(
     imaging_ci_7x7, pre_cti_data_7x7, traps_x1, ccd, parallel_clocker_2d
 ):
 
-    model = af.CollectionPriorModel(
+    model = af.Collection(
         cti=af.Model(ac.CTI2D, parallel_trap_list=traps_x1, parallel_ccd=ccd),
         hyper_noise=af.Model(ac.HyperCINoiseCollection),
     )
@@ -29,7 +53,7 @@ def test__log_likelihood_via_analysis__matches_manual_fit(
     imaging_ci_7x7, pre_cti_data_7x7, traps_x1, ccd, parallel_clocker_2d
 ):
 
-    model = af.CollectionPriorModel(
+    model = af.Collection(
         cti=af.Model(ac.CTI2D, parallel_trap_list=traps_x1, parallel_ccd=ccd),
         hyper_noise=af.Model(ac.HyperCINoiseCollection),
     )
@@ -59,7 +83,7 @@ def test__log_likelihood_via_analysis__fast_settings_same_as_default(
     parallel_serial_clocker_2d,
 ):
 
-    model = af.CollectionPriorModel(
+    model = af.Collection(
         cti=af.Model(ac.CTI2D, parallel_trap_list=traps_x1, parallel_ccd=ccd),
         hyper_noise=af.Model(ac.HyperCINoiseCollection),
     )
@@ -82,7 +106,7 @@ def test__log_likelihood_via_analysis__fast_settings_same_as_default(
 
     assert log_likelihood_via_fast == log_likelihood_via_default
 
-    model = af.CollectionPriorModel(
+    model = af.Collection(
         cti=af.Model(ac.CTI2D, serial_trap_list=traps_x1, serial_ccd=ccd),
         hyper_noise=af.Model(ac.HyperCINoiseCollection),
     )
@@ -105,7 +129,7 @@ def test__log_likelihood_via_analysis__fast_settings_same_as_default(
 
     assert log_likelihood_via_fast == log_likelihood_via_default
 
-    model = af.CollectionPriorModel(
+    model = af.Collection(
         cti=af.Model(
             ac.CTI2D,
             parallel_trap_list=traps_x1,
@@ -145,7 +169,7 @@ def test__full_and_extracted_fits_from_instance_and_imaging_ci(
     imaging_ci_7x7, mask_2d_7x7_unmasked, traps_x1, ccd, parallel_clocker_2d
 ):
 
-    model = af.CollectionPriorModel(
+    model = af.Collection(
         cti=af.Model(ac.CTI2D, parallel_trap_list=traps_x1, parallel_ccd=ccd),
         hyper_noise=af.Model(ac.HyperCINoiseCollection),
     )
@@ -193,7 +217,7 @@ def test__extracted_fits_from_instance_and_imaging_ci__include_noise_scaling(
     layout_ci_7x7,
 ):
 
-    model = af.CollectionPriorModel(
+    model = af.Collection(
         cti=af.Model(ac.CTI2D, parallel_trap_list=traps_x1, parallel_ccd=ccd),
         hyper_noise=af.Model(
             ac.HyperCINoiseCollection, regions_ci=ac.HyperCINoiseScalar

--- a/test_autocti/charge_injection/model/test_analysis_ci.py
+++ b/test_autocti/charge_injection/model/test_analysis_ci.py
@@ -28,7 +28,7 @@ def test__modify_before_fit__noise_normalization_preload(
     analysis = ac.AnalysisImagingCI(dataset=imaging_ci_7x7, clocker=parallel_clocker_2d)
     analysis.modify_before_fit(paths=af.DirectoryPaths(), model=model)
 
-    assert analysis.preloads.noise_normalization == None
+#    assert analysis.preloads.noise_normalization == None
 
 
 def test__make_result__result_imaging_is_returned(


### PR DESCRIPTION
The `noise_normalization` is a term in the `log_likelihood` of a fit, which includes the sum of all `noise_map` values.

In most use cases, this is very fast (< 1.0e-4 seconds) and thus is done every time the code is run.

However, in PyAutoCTI, the large quantity of data means this can take > 0.3s. Preloading the `noise_normalization` can therefore give a nice speed-up, which does feature does.