### PR TITLE
Feature/chi squared fast

### DIFF
--- a/autocti/charge_injection/fit.py
+++ b/autocti/charge_injection/fit.py
@@ -84,7 +84,7 @@ class FitImagingCI(aa.FitImaging):
 
         return aa.util.fit.chi_squared_with_mask_fast_from(
             data=self.dataset.data,
-            noise_map=self.dataset.noise_map,
+            noise_map=self.noise_map,
             mask=self.mask,
             model_data=self.model_data
         )

--- a/autocti/charge_injection/fit.py
+++ b/autocti/charge_injection/fit.py
@@ -67,6 +67,29 @@ class FitImagingCI(aa.FitImaging):
         return self.dataset.pre_cti_data
 
     @property
+    def chi_squared(self) -> float:
+        """
+        Returns the chi-squared terms of the model data's fit to an dataset, by summing the chi-squared-map.
+
+        If the dataset includes a noise covariance matrix, this is used instead to account for covariance in the
+        goodness-of-fit.
+
+        The standard chi-squared calculation in PyAutoArray computes the `chi-squared` from the `residual_map`
+        and `chi_squared_map`, which requires that the `ndarrays` which are used to do this are created and stored
+        in memory. For charge injection imaging, the large datasets mean this can be computationally slow.
+
+        This function computes the `chi_squared` directly from the data, avoiding the need to store the data in memory
+        and offering faster tune times.
+        """
+
+        return aa.util.fit.chi_squared_with_mask_fast_from(
+            data=self.dataset.data,
+            noise_map=self.dataset.noise_map,
+            mask=self.mask,
+            model_data=self.model_data
+        )
+
+    @property
     def noise_normalization(self) -> float:
         """
         Returns the noise-map normalization term of the noise-map, summing the noise_map value in every pixel as:

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -166,21 +166,12 @@ class AnalysisImagingCI(af.Analysis):
             data=imaging_ci.pre_cti_data, cti=instance.cti, preloads=self.preloads
         )
 
-        fit = FitImagingCI(
+        return FitImagingCI(
             dataset=imaging_ci,
             post_cti_data=post_cti_data,
             hyper_noise_scalar_dict=hyper_noise_scalar_dict,
             preloads=self.preloads
         )
-
-        import time
-
-        start = time.time()
-
-        lh = fit.log_likelihood
-
-        print(time.time() - start)
-        return fit
 
     def fit_via_instance_from(
         self, instance: af.ModelInstance, hyper_noise_scale: bool = True

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -166,12 +166,21 @@ class AnalysisImagingCI(af.Analysis):
             data=imaging_ci.pre_cti_data, cti=instance.cti, preloads=self.preloads
         )
 
-        return FitImagingCI(
+        fit = FitImagingCI(
             dataset=imaging_ci,
             post_cti_data=post_cti_data,
             hyper_noise_scalar_dict=hyper_noise_scalar_dict,
             preloads=self.preloads
         )
+
+        import time
+
+        start = time.time()
+
+        lh = fit.log_likelihood
+
+        print(time.time() - start)
+        return fit
 
     def fit_via_instance_from(
         self, instance: af.ModelInstance, hyper_noise_scale: bool = True


### PR DESCRIPTION
The `chi_squared` is a term in the log_likelihood of a fit, which is  (`data` - `model_data` / `noise_map`) ** 2

In most use cases, this is very fast (< 1.0e-4 seconds) and thus is done in a series of separate function calls for readability, which store different `ndarrays` in memory. 

However, in PyAutoCTI, the large quantity of data means this can take > 0.3s. A fast chi-squared calculation which performs the calculation on all memories at once is therefore implemented.