### PR TITLE
Feature/typing

### DIFF
--- a/autocti/charge_injection/layout.py
+++ b/autocti/charge_injection/layout.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
 import numpy as np
 import math
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from autocti.extract.two_d.master import Extract2DMaster
+
 import autoarray as aa
 
-from autocti.charge_injection import ci_util
+from autoarray.layout import layout_util
+
 from autocti.instruments.euclid.layout import Layout2DEuclid
 from autocti.layout.two_d import Layout2D
 
-
-from autoarray.layout import layout_util
+from autocti.charge_injection import ci_util
 
 
 class Layout2DCI(Layout2D):
@@ -63,7 +68,7 @@ class Layout2DCI(Layout2D):
         self.electronics = electronics
 
     @property
-    def extract(self) -> "Extract2DMaster":
+    def extract(self) -> Extract2DMaster:
 
         from autocti.extract.two_d.master import Extract2DMaster
 

--- a/autocti/clocker/abstract.py
+++ b/autocti/clocker/abstract.py
@@ -25,7 +25,7 @@ class AbstractClocker(Dictable):
         self.iterations = iterations
         self.verbosity = verbosity
 
-    def ccd_from(self, ccd_phase: "CCDPhase") -> "CCD":
+    def ccd_from(self, ccd_phase: CCDPhase) -> CCD:
         """
         Returns a `CCD` object from a `CCDPhase` object.
 
@@ -46,8 +46,8 @@ class AbstractClocker(Dictable):
 
     def check_traps(
         self,
-        trap_list_0: Optional[List["TrapInstantCapture"]],
-        trap_list_1: Optional[List["TrapInstantCapture"]] = None,
+        trap_list_0: Optional[List[TrapInstantCapture]],
+        trap_list_1: Optional[List[TrapInstantCapture]] = None,
     ):
         """
         Checks that there are trap species passed to the clocking algorithm and raises an exception if not.
@@ -62,7 +62,7 @@ class AbstractClocker(Dictable):
                 "No Trap species were passed to the add_cti method"
             )
 
-    def check_ccd(self, ccd_list: List["CCDPhase"]):
+    def check_ccd(self, ccd_list: List[CCDPhase]):
         """
         Checks that there are trap species passed to the clocking algorithm and raises an exception if not.
 

--- a/autocti/clocker/one_d.py
+++ b/autocti/clocker/one_d.py
@@ -15,7 +15,7 @@ class Clocker1D(AbstractClocker):
     def __init__(
         self,
         iterations: int = 5,
-        roe: Optional["ROE"] = None,
+        roe: Optional[ROE] = None,
         express: int = 0,
         window_start: int = 0,
         window_stop: int = -1,

--- a/autocti/clocker/two_d.py
+++ b/autocti/clocker/two_d.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from arcticpy import add_cti
 from arcticpy import remove_cti
+
 from arcticpy import ROE
 
 import autoarray as aa
@@ -16,7 +17,7 @@ class Clocker2D(AbstractClocker):
     def __init__(
         self,
         iterations: int = 5,
-        parallel_roe: Optional["ROE"] = None,
+        parallel_roe: Optional[ROE] = None,
         parallel_express: int = 0,
         parallel_window_offset: int = 0,
         parallel_window_start: int = 0,

--- a/autocti/clocker/two_d.py
+++ b/autocti/clocker/two_d.py
@@ -28,7 +28,7 @@ class Clocker2D(AbstractClocker):
         parallel_prune_frequency=0,
         parallel_poisson_traps: bool = False,
         parallel_fast_mode: Optional[bool] = False,
-        serial_roe: Optional["ROE"] = None,
+        serial_roe: Optional[ROE] = None,
         serial_express: int = 0,
         serial_window_offset: int = 0,
         serial_window_start: int = 0,

--- a/autocti/extract/two_d/parallel/calibration.py
+++ b/autocti/extract/two_d/parallel/calibration.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 import autoarray as aa
 
+from autocti.charge_injection.layout import Layout2DCI
 from autocti.charge_injection.imaging.imaging import ImagingCI
 from autocti.mask.mask_2d import Mask2D
 
@@ -84,7 +85,7 @@ class Extract2DParallelCalibration:
             shape_2d=self.shape_2d, pixels=columns
         )
 
-    def mask_2d_from(self, mask: aa.Mask2D, columns: Tuple[int, int]) -> "Mask2D":
+    def mask_2d_from(self, mask: aa.Mask2D, columns: Tuple[int, int]) -> Mask2D:
         """
         Extract a mask to go with a parallel calibration array from an input mask.
 
@@ -150,7 +151,7 @@ class Extract2DParallelCalibration:
             header=array.header,
         )
 
-    def extracted_layout_from(self, layout, columns: Tuple[int, int]) -> "Layout2DCI":
+    def extracted_layout_from(self, layout, columns: Tuple[int, int]) -> Layout2DCI:
         """
         Extract the layout of a parallel calibration array from an input layout, where this layout contains the regions
         of the input layout which are retained after the parallel CTI calibration array is created. This layout
@@ -204,7 +205,7 @@ class Extract2DParallelCalibration:
 
     def with_extracted_regions(
         self, layout, extraction_region: aa.type.Region2DLike
-    ) -> "Layout2DCI":
+    ) -> Layout2DCI:
 
         layout = deepcopy(layout)
 

--- a/autocti/extract/two_d/parallel/calibration.py
+++ b/autocti/extract/two_d/parallel/calibration.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 import autoarray as aa
 
+from autocti.charge_injection.imaging.imaging import ImagingCI
 from autocti.mask.mask_2d import Mask2D
 
 
@@ -223,8 +224,8 @@ class Extract2DParallelCalibration:
         return layout
 
     def imaging_ci_from(
-        self, imaging_ci: "ImagingCI", columns: Tuple[int, int]
-    ) -> "ImagingCI":
+        self, imaging_ci: ImagingCI, columns: Tuple[int, int]
+    ) -> ImagingCI:
         """
         Returnss a function to extract a parallel section for given columns
         """

--- a/autocti/extract/two_d/serial/calibration.py
+++ b/autocti/extract/two_d/serial/calibration.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 
 import autoarray as aa
 
+from autocti.charge_injection.imaging.imaging import ImagingCI
 from autocti.mask.mask_2d import Mask2D
 
 
@@ -221,7 +222,7 @@ class Extract2DSerialCalibration:
 
         return new_layout
 
-    def imaging_ci_from(self, imaging_ci: "ImagingCI", rows) -> "ImagingCI":
+    def imaging_ci_from(self, imaging_ci: ImagingCI, rows) -> ImagingCI:
         """
         Returnss a function to extract a serial section for given rows
         """

--- a/autocti/mask/mask_2d.py
+++ b/autocti/mask/mask_2d.py
@@ -5,6 +5,7 @@ import autoarray as aa
 
 from autoarray import exc
 
+from autocti.layout.two_d import Layout2D
 
 class SettingsMask2D:
     def __init__(
@@ -197,7 +198,7 @@ class Mask2D(aa.Mask2D):
     def masked_fpr_and_eper_from(
         cls,
         mask: "Mask2D",
-        layout: "Layout2D",
+        layout: Layout2D,
         settings: "SettingsMask2D",
         pixel_scales: aa.type.PixelScales,
     ) -> "Mask2D":
@@ -239,7 +240,7 @@ class Mask2D(aa.Mask2D):
     @classmethod
     def masked_parallel_fpr_from(
         cls,
-        layout: "Layout2D",
+        layout: Layout2D,
         settings: "SettingsMask2D",
         pixel_scales: aa.type.PixelScales,
         invert: bool = False,
@@ -261,7 +262,7 @@ class Mask2D(aa.Mask2D):
     @classmethod
     def masked_parallel_eper_from(
         cls,
-        layout: "Layout2D",
+        layout: Layout2D,
         settings: "SettingsMask2D",
         pixel_scales: aa.type.PixelScales,
         invert: bool = False,
@@ -284,7 +285,7 @@ class Mask2D(aa.Mask2D):
     @classmethod
     def masked_serial_fpr_from(
         cls,
-        layout: "Layout2D",
+        layout: Layout2D,
         settings: "SettingsMask2D",
         pixel_scales: aa.type.PixelScales,
         invert: bool = False,
@@ -306,7 +307,7 @@ class Mask2D(aa.Mask2D):
     @classmethod
     def masked_serial_eper_from(
         cls,
-        layout: "Layout2D",
+        layout: Layout2D,
         settings: "SettingsMask2D",
         pixel_scales: aa.type.PixelScales,
         invert: bool = False,

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -37,7 +37,7 @@ For charge injection datasets taken with a CCD (or similar imaging device).
 1D Data Structures
 ------------------
 
-Two-dimensional data structures store and mask 1D arrays containing data (e.g. 1D CTI datasets
+One-dimensional data structures store and mask 1D arrays containing data (e.g. 1D CTI datasets
 images) and grids of (y,x) Cartesian coordinates.
 
 .. autosummary::
@@ -50,7 +50,6 @@ images) and grids of (y,x) Cartesian coordinates.
    ValuesIrregular
    Grid1D
 
-----------
 Dataset 1D
 ----------
 


### PR DESCRIPTION
Use the following API to perform typing when we previously couldn't, which helps readthedocs:

```
from __future__ import annotations

from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from autoarray.structures.abstract_structure import Structure
```