### PR TITLE
Feature/samples summary in result

### DIFF
--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -465,6 +465,9 @@ class AnalysisImagingCI(AnalysisCTI):
 
     def make_result(
         self,
-        samples: af.SamplesPDF, search_internal = None
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
     ) -> ResultImagingCI:
-        return ResultImagingCI(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultImagingCI(samples_summary=samples_summary, paths=paths, samples=samples, analysis=self, search_internal=search_internal)

--- a/autocti/dataset_1d/model/analysis.py
+++ b/autocti/dataset_1d/model/analysis.py
@@ -325,6 +325,9 @@ class AnalysisDataset1D(AnalysisCTI):
 
     def make_result(
         self,
-        samples: af.SamplesPDF, search_internal = None
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
     ) -> ResultDataset1D:
-        return ResultDataset1D(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultDataset1D(samples_summary=samples_summary, paths=paths, samples=samples, analysis=self, search_internal=search_internal)

--- a/autocti/fixtures.py
+++ b/autocti/fixtures.py
@@ -1,4 +1,4 @@
-from autofit.non_linear.mock.mock_samples import MockSamples
+from autofit.non_linear.mock.mock_samples_summary import MockSamplesSummary
 
 from autoarray.fixtures import *
 
@@ -208,7 +208,7 @@ def make_fit_ci_7x7():
 # ### PHASES ###
 
 
-def make_samples_with_result():
+def make_samples_summary_with_result():
     model = af.Collection(
         cti=af.Model(
             ac.CTI2D,
@@ -221,9 +221,9 @@ def make_samples_with_result():
 
     instance = model.instance_from_prior_medians()
 
-    return MockSamples(
-        model=model,
+    return MockSamplesSummary(
         max_log_likelihood_instance=instance,
+        model=model,
         prior_means=[1.0] * model.prior_count,
     )
 

--- a/autocti/model/result.py
+++ b/autocti/model/result.py
@@ -2,11 +2,11 @@ from autofit.non_linear import result
 
 
 class Result(result.Result):
-    def __init__(self, samples, analysis, search_internal = None):
+    def __init__(self, samples_summary, paths, samples, analysis, search_internal = None):
         """
         The result of a phase
         """
-        super().__init__(samples=samples, search_internal=search_internal)
+        super().__init__(samples_summary=samples_summary, paths=paths, samples=samples, search_internal=search_internal)
 
         self.analysis = analysis
 

--- a/autocti/model/result.py
+++ b/autocti/model/result.py
@@ -2,7 +2,7 @@ from autofit.non_linear import result
 
 
 class Result(result.Result):
-    def __init__(self, samples_summary, paths, samples, analysis, search_internal = None):
+    def __init__(self, samples_summary, paths=None, samples=None, analysis=None, search_internal = None):
         """
         The result of a phase
         """

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -47,11 +47,9 @@ by **PyAutoCTI**.
    :template: custom-class-template.rst
    :recursive:
 
-   DynestyPlotter
-   UltraNestPlotter
-   EmceePlotter
-   ZeusPlotter
-   PySwarmsPlotter
+   NestPlotter
+   MCMCPlotter
+   OptimizePlotter
 
 Plot Customization [aplt]
 -------------------------

--- a/test_autocti/aggregator/conftest.py
+++ b/test_autocti/aggregator/conftest.py
@@ -60,10 +60,6 @@ def make_model_1d():
 
 @pytest.fixture(name="samples_1d")
 def make_samples_1d(model_1d):
-    trap_0 = ac.TrapInstantCapture(density=0.1, release_timescale=1.0)
-    ccd = ac.CCDPhase()
-
-    cti = ac.CTI1D(trap_list=[trap_0], ccd=ccd)
 
     parameters = [model_1d.prior_count * [1.0], model_1d.prior_count * [10.0]]
 
@@ -78,7 +74,6 @@ def make_samples_1d(model_1d):
     return ac.m.MockSamples(
         model=model_1d,
         sample_list=sample_list,
-        max_log_likelihood_instance=cti,
         prior_means=[1.0] * model_1d.prior_count,
     )
 
@@ -98,10 +93,6 @@ def make_model_2d():
 
 @pytest.fixture(name="samples_2d")
 def make_samples_2d(model_2d):
-    trap_0 = ac.TrapInstantCapture(density=0.1, release_timescale=1.0)
-    ccd = ac.CCDPhase()
-
-    cti = ac.CTI2D(parallel_trap_list=[trap_0], parallel_ccd=ccd)
 
     parameters = [model_2d.prior_count * [1.0], model_2d.prior_count * [10.0]]
 
@@ -116,6 +107,5 @@ def make_samples_2d(model_2d):
     return ac.m.MockSamples(
         model=model_2d,
         sample_list=sample_list,
-        max_log_likelihood_instance=cti,
         prior_means=[1.0] * model_2d.prior_count,
     )

--- a/test_autocti/analysis/test_result.py
+++ b/test_autocti/analysis/test_result.py
@@ -1,16 +1,14 @@
-import autofit as af
 import autocti as ac
 from autocti.model import result as res
 
 import numpy as np
-import pytest
 
 
 def test__result_contains_instance_with_cti_model(
     analysis_imaging_ci_7x7, samples_summary_with_result
 ):
     result = res.Result(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -22,7 +20,7 @@ def test__clocker_passed_as_result_correctly(
     analysis_imaging_ci_7x7, samples_summary_with_result, parallel_clocker_2d
 ):
     result = res.Result(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -38,7 +36,7 @@ def test__masks_available_as_property(
     ccd,
 ):
     result = res.ResultDataset(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 

--- a/test_autocti/analysis/test_result.py
+++ b/test_autocti/analysis/test_result.py
@@ -7,10 +7,10 @@ import pytest
 
 
 def test__result_contains_instance_with_cti_model(
-    analysis_imaging_ci_7x7, samples_with_result
+    analysis_imaging_ci_7x7, samples_summary_with_result
 ):
     result = res.Result(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -19,10 +19,10 @@ def test__result_contains_instance_with_cti_model(
 
 
 def test__clocker_passed_as_result_correctly(
-    analysis_imaging_ci_7x7, samples_with_result, parallel_clocker_2d
+    analysis_imaging_ci_7x7, samples_summary_with_result, parallel_clocker_2d
 ):
     result = res.Result(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -32,13 +32,13 @@ def test__clocker_passed_as_result_correctly(
 
 def test__masks_available_as_property(
     analysis_imaging_ci_7x7,
-    samples_with_result,
+    samples_summary_with_result,
     parallel_clocker_2d,
     traps_x1,
     ccd,
 ):
     result = res.ResultDataset(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 

--- a/test_autocti/charge_injection/model/test_result_ci.py
+++ b/test_autocti/charge_injection/model/test_result_ci.py
@@ -8,7 +8,7 @@ from autocti.charge_injection.model.result import ResultImagingCI
 
 
 def test__fits_to_extracted_and_full_datasets_available(
-    imaging_ci_7x7, mask_2d_7x7_unmasked, parallel_clocker_2d, samples_with_result
+    imaging_ci_7x7, mask_2d_7x7_unmasked, parallel_clocker_2d, samples_summary_with_result
 ):
     imaging_ci_full = copy.deepcopy(imaging_ci_7x7)
 
@@ -24,7 +24,7 @@ def test__fits_to_extracted_and_full_datasets_available(
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis,
     )
 
@@ -43,7 +43,7 @@ def test__noise_scaling_map_dict_is_list_of_result__are_correct(
     mask_2d_7x7_unmasked,
     parallel_clocker_2d,
     layout_ci_7x7,
-    samples_with_result,
+    samples_summary_with_result,
     traps_x1,
     ccd,
 ):
@@ -80,11 +80,11 @@ def test__noise_scaling_map_dict_is_list_of_result__are_correct(
     )
 
     fit_analysis = analysis.fit_via_instance_from(
-        instance=samples_with_result.max_log_likelihood()
+        instance=samples_summary_with_result.max_log_likelihood()
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis,
     )
 

--- a/test_autocti/charge_injection/model/test_result_ci.py
+++ b/test_autocti/charge_injection/model/test_result_ci.py
@@ -4,7 +4,6 @@ import pytest
 
 import autofit as af
 import autocti as ac
-from autocti.charge_injection.model.result import ResultImagingCI
 
 
 def test__fits_to_extracted_and_full_datasets_available(
@@ -24,7 +23,7 @@ def test__fits_to_extracted_and_full_datasets_available(
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis,
     )
 
@@ -84,7 +83,7 @@ def test__noise_scaling_map_dict_is_list_of_result__are_correct(
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis,
     )
 

--- a/test_autocti/conftest.py
+++ b/test_autocti/conftest.py
@@ -229,9 +229,9 @@ def make_fit_ci_7x7():
 from autofit.mapper.model import ModelInstance
 
 
-@pytest.fixture(name="samples_with_result")
-def make_samples_with_result():
-    return fixtures.make_samples_with_result()
+@pytest.fixture(name="samples_summary_with_result")
+def make_samples_summary_with_result():
+    return fixtures.make_samples_summary_with_result()
 
 
 @pytest.fixture(name="analysis_imaging_ci_7x7")


### PR DESCRIPTION
Make it so that all internal results loading use the `SamplesSummary` object instead of the `Samples` object wherever possible.

This has two benefits:

-Loading `samples.csv` /  `search_internal.dill` in order to load results when resuming a model-fit was very slow.

- Recent updates to `output.yaml` mean autofit can now run without outputting a `samples.csv` file or `search_internal.dill` file at all (to save hard disk space).  The samples summary file cannot be customized to not be output, meaning the information for resuming runs is always available.

This is motivated for search chaining prior passing, which by using the `SamplesSummary` resumes previous fits much faster.