### PR TITLE
Feature/readout persistence

### DIFF
--- a/autocti/__init__.py
+++ b/autocti/__init__.py
@@ -45,6 +45,7 @@ from .extract.two_d.master import Extract2DMaster
 from .instruments import euclid
 from .instruments import acs
 from .charge_injection.fit import FitImagingCI
+from .charge_injection.imaging.readout_persistence import ReadoutPersistence
 from .mask.mask_2d import Mask2D
 from .mask.mask_2d import SettingsMask2D
 from .mask.mask_1d import Mask1D

--- a/autocti/charge_injection/imaging/readout_persistence.py
+++ b/autocti/charge_injection/imaging/readout_persistence.py
@@ -1,6 +1,7 @@
 import numpy as np
 from typing import Optional, Tuple
 
+import autoarray as aa
 
 class ReadoutPersistence:
 
@@ -12,6 +13,39 @@ class ReadoutPersistence:
         rows_per_persistence_range: Optional[Tuple[int, int]] =  (1, 10),
         seed: int = -1,
     ):
+        """
+        Adds readout persistence to a 2D array of data, typically for simulating charge injection data.
+
+        Readout persistence is a feature of CCD detectors (e.g. the Euclid VIS detector), whereby after bright
+        delta-function like sources (e.g. cosmic rays) are detected, the electronics does not properly reset its bias
+        level to zero, but instead gets stuck at a higher value (e.g. 3e- to 10e-). Tis persistence appears as rows of
+        elevated signal in the charge injection data.
+
+        If not masked, this elevated signal appears as spikes in the parallel EPER trails, degrading the quality of
+        CTI calibration.
+
+        This class adds readout persistence to a 2D array of data, whereby a number of rows are selected at random and
+        a value drawn from a Gaussian distribution is added to them. The number of rows and value drawn from the
+        Gaussian distribution are input as parameters.
+
+        This simulation does not pair the location of readout persistence with the location of the location of delta
+        function like sources, but instead adds it to random rows in the data. This choice is for simplicity and
+        because all masking techniques do not use the point-source locations to mask readout persistence.
+
+        Parameters
+        ----------
+        total_rows
+            The total number of distinct rows where readout persistence is added to the data. Note that for each row
+            multiple rows are added, drawn randomly from the range `rows_per_persistence_range`.
+        mean
+            The mean of the Gaussian distribution from which the value added to the data is drawn.
+        sigma
+            The sigma of the Gaussian distribution from which the value added to the data is drawn.
+        rows_per_persistence_range
+            The range of the number of rows added to the data for each row where readout persistence is added.
+        seed
+            The seed used to initialize the random number generator. If -1, a random seed is used.
+        """
 
         self.total_rows = total_rows
         self.mean = mean
@@ -19,8 +53,25 @@ class ReadoutPersistence:
         self.rows_per_persistence_range = rows_per_persistence_range
         self.seed = seed
 
-    def data_with_readout_persistence_from(self, data):
+    def data_with_readout_persistence_from(self, data : aa.Array2D) -> aa.Array2D:
+        """
+        Returns the input data with readout persistence added to it.
 
+        This function adds readout persistence to the input data, whereby a number of rows are selected at random and
+        a value drawn from a Gaussian distribution is added to them. The number of rows and value drawn from the
+        Gaussian distribution are input as parameters.
+
+        The `__init__` method describes how the readout persistence is simulated.
+
+        Parameters
+        ----------
+        data
+            The 2D array of data to which readout persistence is added.
+
+        Returns
+        -------
+        The input data with readout persistence added to it.
+        """
         for i in range(self.total_rows):
 
             if self.seed == -1:
@@ -37,10 +88,6 @@ class ReadoutPersistence:
 
             row_index = np.random.randint(0, data.shape[0])
             row_range = np.random.randint(self.rows_per_persistence_range[0], self.rows_per_persistence_range[1])
-
-            print(row_value)
-            print(row_index)
-            print(row_range)
 
             data[row_index:row_index+row_range] += row_value
 

--- a/autocti/charge_injection/imaging/readout_persistence.py
+++ b/autocti/charge_injection/imaging/readout_persistence.py
@@ -1,0 +1,34 @@
+import numpy as np
+from typing import Optional, Tuple
+
+
+class ReadoutPersistence:
+
+    def __init__(
+        self,
+        total_rows: Optional[int] = 10,
+        mean : Optional[float] = 5.0,
+        sigma: Optional[float] = 1.0,
+        rows_per_persistence_range: Optional[Tuple[int, int]] =  (1, 10),
+    ):
+
+        self.total_rows = total_rows
+        self.mean = mean
+        self.sigma = sigma
+        self.rows_per_persistence_range = rows_per_persistence_range
+
+    def data_with_readout_persistence_from(self, data):
+
+        for i in range(self.total_rows):
+
+            row_value = 0.0
+
+            while row_value <= 0.0:
+                row_value = np.random.normal(self.mean, self.sigma)
+
+            row_index = np.random.randint(0, data.shape[0])
+            row_range = np.random.randint(1, 10)
+
+            data[row_index:row_range] += row_value
+
+        return data

--- a/autocti/charge_injection/imaging/readout_persistence.py
+++ b/autocti/charge_injection/imaging/readout_persistence.py
@@ -10,14 +10,23 @@ class ReadoutPersistence:
         mean : Optional[float] = 5.0,
         sigma: Optional[float] = 1.0,
         rows_per_persistence_range: Optional[Tuple[int, int]] =  (1, 10),
+        seed: int = -1,
     ):
 
         self.total_rows = total_rows
         self.mean = mean
         self.sigma = sigma
         self.rows_per_persistence_range = rows_per_persistence_range
+        self.seed = seed
 
     def data_with_readout_persistence_from(self, data):
+        
+        if self.seed == -1:
+            seed = np.random.randint(0, int(1e9))
+        else:
+            seed = self.seed
+
+        np.random.seed(seed)
 
         for i in range(self.total_rows):
 

--- a/autocti/charge_injection/imaging/readout_persistence.py
+++ b/autocti/charge_injection/imaging/readout_persistence.py
@@ -20,15 +20,15 @@ class ReadoutPersistence:
         self.seed = seed
 
     def data_with_readout_persistence_from(self, data):
-        
-        if self.seed == -1:
-            seed = np.random.randint(0, int(1e9))
-        else:
-            seed = self.seed
-
-        np.random.seed(seed)
 
         for i in range(self.total_rows):
+
+            if self.seed == -1:
+                seed = np.random.randint(0, int(1e9))
+            else:
+                seed = self.seed + i
+
+            np.random.seed(seed)
 
             row_value = 0.0
 
@@ -36,8 +36,12 @@ class ReadoutPersistence:
                 row_value = np.random.normal(self.mean, self.sigma)
 
             row_index = np.random.randint(0, data.shape[0])
-            row_range = np.random.randint(1, 10)
+            row_range = np.random.randint(self.rows_per_persistence_range[0], self.rows_per_persistence_range[1])
 
-            data[row_index:row_range] += row_value
+            print(row_value)
+            print(row_index)
+            print(row_range)
+
+            data[row_index:row_index+row_range] += row_value
 
         return data

--- a/autocti/charge_injection/imaging/simulator.py
+++ b/autocti/charge_injection/imaging/simulator.py
@@ -7,6 +7,7 @@ import autoarray as aa
 from autoarray.dataset.imaging.simulator import SimulatorImaging
 
 from autocti.charge_injection.imaging.imaging import ImagingCI
+from autocti.charge_injection.imaging.readout_persistence import ReadoutPersistence
 from autocti.charge_injection.layout import Layout2DCI
 from autocti.clocker.two_d import Clocker2D
 from autocti.extract.settings import SettingsExtract
@@ -27,6 +28,7 @@ class SimulatorImagingCI(SimulatorImaging):
         read_noise: Optional[float] = None,
         charge_noise: Optional[float] = None,
         stray_light: Optional[Tuple[float, float]] = None,
+        readout_persistance : Optional[ReadoutPersistence] = None,
         flat_field_mode: bool = False,
         noise_if_add_noise_false: float = 0.1,
         noise_seed: int = -1,
@@ -57,6 +59,7 @@ class SimulatorImagingCI(SimulatorImaging):
         self.read_noise = read_noise
         self.charge_noise = charge_noise
         self.stray_light = stray_light
+        self.readout_persistance =  readout_persistance
         self.flat_field_mode = flat_field_mode
 
         self.ci_seed = ci_seed
@@ -237,6 +240,12 @@ class SimulatorImagingCI(SimulatorImaging):
             post_cti_data = clocker.add_cti(data=pre_cti_data, cti=cti)
         else:
             post_cti_data = copy.copy(pre_cti_data)
+
+        if self.readout_persistance is not None:
+
+            post_cti_data = self.readout_persistance.data_with_readout_persistence_from(
+                data=post_cti_data
+            )
 
         if cosmic_ray_map is not None:
             pre_cti_data -= cosmic_ray_map.native

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -465,6 +465,9 @@ class AnalysisImagingCI(AnalysisCTI):
 
     def make_result(
         self,
-        samples: af.SamplesPDF, search_internal = None
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
     ) -> ResultImagingCI:
-        return ResultImagingCI(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultImagingCI(samples_summary=samples_summary, paths=paths, samples=samples, analysis=self, search_internal=search_internal)

--- a/autocti/dataset_1d/model/analysis.py
+++ b/autocti/dataset_1d/model/analysis.py
@@ -325,6 +325,9 @@ class AnalysisDataset1D(AnalysisCTI):
 
     def make_result(
         self,
-        samples: af.SamplesPDF, search_internal = None
+        samples_summary: af.SamplesSummary,
+        paths: af.AbstractPaths,
+        samples: Optional[af.SamplesPDF] = None,
+        search_internal: Optional[object] = None,
     ) -> ResultDataset1D:
-        return ResultDataset1D(samples=samples, analysis=self, search_internal=search_internal)
+        return ResultDataset1D(samples_summary=samples_summary, paths=paths, samples=samples, analysis=self, search_internal=search_internal)

--- a/autocti/fixtures.py
+++ b/autocti/fixtures.py
@@ -1,4 +1,4 @@
-from autofit.non_linear.mock.mock_samples import MockSamples
+from autofit.non_linear.mock.mock_samples_summary import MockSamplesSummary
 
 from autoarray.fixtures import *
 
@@ -208,7 +208,7 @@ def make_fit_ci_7x7():
 # ### PHASES ###
 
 
-def make_samples_with_result():
+def make_samples_summary_with_result():
     model = af.Collection(
         cti=af.Model(
             ac.CTI2D,
@@ -221,9 +221,9 @@ def make_samples_with_result():
 
     instance = model.instance_from_prior_medians()
 
-    return MockSamples(
-        model=model,
+    return MockSamplesSummary(
         max_log_likelihood_instance=instance,
+        model=model,
         prior_means=[1.0] * model.prior_count,
     )
 

--- a/autocti/model/result.py
+++ b/autocti/model/result.py
@@ -2,11 +2,11 @@ from autofit.non_linear import result
 
 
 class Result(result.Result):
-    def __init__(self, samples, analysis, search_internal = None):
+    def __init__(self, samples_summary, paths, samples, analysis, search_internal = None):
         """
         The result of a phase
         """
-        super().__init__(samples=samples, search_internal=search_internal)
+        super().__init__(samples_summary=samples_summary, paths=paths, samples=samples, search_internal=search_internal)
 
         self.analysis = analysis
 

--- a/autocti/model/result.py
+++ b/autocti/model/result.py
@@ -2,7 +2,7 @@ from autofit.non_linear import result
 
 
 class Result(result.Result):
-    def __init__(self, samples_summary, paths, samples, analysis, search_internal = None):
+    def __init__(self, samples_summary, paths=None, samples=None, analysis=None, search_internal = None):
         """
         The result of a phase
         """

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -47,11 +47,9 @@ by **PyAutoCTI**.
    :template: custom-class-template.rst
    :recursive:
 
-   DynestyPlotter
-   UltraNestPlotter
-   EmceePlotter
-   ZeusPlotter
-   PySwarmsPlotter
+   NestPlotter
+   MCMCPlotter
+   OptimizePlotter
 
 Plot Customization [aplt]
 -------------------------

--- a/test_autocti/aggregator/conftest.py
+++ b/test_autocti/aggregator/conftest.py
@@ -60,10 +60,6 @@ def make_model_1d():
 
 @pytest.fixture(name="samples_1d")
 def make_samples_1d(model_1d):
-    trap_0 = ac.TrapInstantCapture(density=0.1, release_timescale=1.0)
-    ccd = ac.CCDPhase()
-
-    cti = ac.CTI1D(trap_list=[trap_0], ccd=ccd)
 
     parameters = [model_1d.prior_count * [1.0], model_1d.prior_count * [10.0]]
 
@@ -78,7 +74,6 @@ def make_samples_1d(model_1d):
     return ac.m.MockSamples(
         model=model_1d,
         sample_list=sample_list,
-        max_log_likelihood_instance=cti,
         prior_means=[1.0] * model_1d.prior_count,
     )
 
@@ -98,10 +93,6 @@ def make_model_2d():
 
 @pytest.fixture(name="samples_2d")
 def make_samples_2d(model_2d):
-    trap_0 = ac.TrapInstantCapture(density=0.1, release_timescale=1.0)
-    ccd = ac.CCDPhase()
-
-    cti = ac.CTI2D(parallel_trap_list=[trap_0], parallel_ccd=ccd)
 
     parameters = [model_2d.prior_count * [1.0], model_2d.prior_count * [10.0]]
 
@@ -116,6 +107,5 @@ def make_samples_2d(model_2d):
     return ac.m.MockSamples(
         model=model_2d,
         sample_list=sample_list,
-        max_log_likelihood_instance=cti,
         prior_means=[1.0] * model_2d.prior_count,
     )

--- a/test_autocti/analysis/test_result.py
+++ b/test_autocti/analysis/test_result.py
@@ -1,16 +1,14 @@
-import autofit as af
 import autocti as ac
 from autocti.model import result as res
 
 import numpy as np
-import pytest
 
 
 def test__result_contains_instance_with_cti_model(
     analysis_imaging_ci_7x7, samples_summary_with_result
 ):
     result = res.Result(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -22,7 +20,7 @@ def test__clocker_passed_as_result_correctly(
     analysis_imaging_ci_7x7, samples_summary_with_result, parallel_clocker_2d
 ):
     result = res.Result(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -38,7 +36,7 @@ def test__masks_available_as_property(
     ccd,
 ):
     result = res.ResultDataset(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 

--- a/test_autocti/analysis/test_result.py
+++ b/test_autocti/analysis/test_result.py
@@ -7,10 +7,10 @@ import pytest
 
 
 def test__result_contains_instance_with_cti_model(
-    analysis_imaging_ci_7x7, samples_with_result
+    analysis_imaging_ci_7x7, samples_summary_with_result
 ):
     result = res.Result(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -19,10 +19,10 @@ def test__result_contains_instance_with_cti_model(
 
 
 def test__clocker_passed_as_result_correctly(
-    analysis_imaging_ci_7x7, samples_with_result, parallel_clocker_2d
+    analysis_imaging_ci_7x7, samples_summary_with_result, parallel_clocker_2d
 ):
     result = res.Result(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 
@@ -32,13 +32,13 @@ def test__clocker_passed_as_result_correctly(
 
 def test__masks_available_as_property(
     analysis_imaging_ci_7x7,
-    samples_with_result,
+    samples_summary_with_result,
     parallel_clocker_2d,
     traps_x1,
     ccd,
 ):
     result = res.ResultDataset(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis_imaging_ci_7x7,
     )
 

--- a/test_autocti/charge_injection/imaging/test_simulator_ci.py
+++ b/test_autocti/charge_injection/imaging/test_simulator_ci.py
@@ -239,24 +239,32 @@ def test__include_stray_light__is_added_before_cti(parallel_clocker_2d, traps_x2
 def test__include_readout_persistance__is_added_after_cti(parallel_clocker_2d, traps_x2, ccd):
 
     layout = ac.Layout2DCI(
-        shape_2d=(3, 3),
+        shape_2d=(9, 3),
         region_list=[(0, 1, 0, 3)],
-        parallel_overscan=ac.Region2D((1, 2, 0, 3)),
-        serial_overscan=ac.Region2D((1, 2, 1, 2)),
+        parallel_overscan=ac.Region2D((8, 9, 0, 3)),
+        serial_overscan=ac.Region2D((1, 8, 1, 2)),
     )
 
     simulator = ac.SimulatorImagingCI(
         pixel_scales=1.0,
         norm=0.0,
-        readout_persistance=
+        readout_persistance=ac.ReadoutPersistence(
+            total_rows=2,
+            mean=5.0,
+            sigma=1.0,
+            rows_per_persistence_range=(1, 4),
+            seed=1
+        )
     )
 
     dataset = simulator.via_layout_from(
-        layout=layout, clocker=parallel_clocker_2d, cti=None
+        layout=layout, clocker=parallel_clocker_2d, cti=None,
     )
 
-    assert dataset.data[0, 0:3] == pytest.approx(1.0, 1.0e-4)
-    assert dataset.data[1, 0:3] == pytest.approx(0.998, 1.0e-4)
+    assert dataset.data[1, 5] == pytest.approx(6.62434, 1.0e-4)
+    assert dataset.data[1, 6] == pytest.approx(4.583242, 1.0e-4)
+    assert dataset.data[1, 7] == pytest.approx(4.583242, 1.0e-4)
+    assert dataset.data[1, 8] == pytest.approx(4.583242, 1.0e-4)
 
 
 def test__include_read_noise__is_added_after_cti(parallel_clocker_2d, traps_x2, ccd):

--- a/test_autocti/charge_injection/imaging/test_simulator_ci.py
+++ b/test_autocti/charge_injection/imaging/test_simulator_ci.py
@@ -261,10 +261,10 @@ def test__include_readout_persistance__is_added_after_cti(parallel_clocker_2d, t
         layout=layout, clocker=parallel_clocker_2d, cti=None,
     )
 
-    assert dataset.data[1, 5] == pytest.approx(6.62434, 1.0e-4)
-    assert dataset.data[1, 6] == pytest.approx(4.583242, 1.0e-4)
-    assert dataset.data[1, 7] == pytest.approx(4.583242, 1.0e-4)
-    assert dataset.data[1, 8] == pytest.approx(4.583242, 1.0e-4)
+    assert dataset.data[5, :] == pytest.approx(6.62434, 1.0e-4)
+    assert dataset.data[6, :] == pytest.approx(4.583242, 1.0e-4)
+    assert dataset.data[7, :] == pytest.approx(4.583242, 1.0e-4)
+    assert dataset.data[8, :] == pytest.approx(4.583242, 1.0e-4)
 
 
 def test__include_read_noise__is_added_after_cti(parallel_clocker_2d, traps_x2, ccd):

--- a/test_autocti/charge_injection/imaging/test_simulator_ci.py
+++ b/test_autocti/charge_injection/imaging/test_simulator_ci.py
@@ -236,6 +236,28 @@ def test__include_stray_light__is_added_before_cti(parallel_clocker_2d, traps_x2
     assert dataset.data[1, 0:3] == pytest.approx(0.998, 1.0e-4)
 
 
+def test__include_readout_persistance__is_added_after_cti(parallel_clocker_2d, traps_x2, ccd):
+    layout = ac.Layout2DCI(
+        shape_2d=(3, 3),
+        region_list=[(0, 1, 0, 3)],
+        parallel_overscan=ac.Region2D((1, 2, 0, 3)),
+        serial_overscan=ac.Region2D((1, 2, 1, 2)),
+    )
+
+    simulator = ac.SimulatorImagingCI(
+        pixel_scales=1.0,
+        norm=0.0,
+        stray_light=(-0.002, 1.0),
+    )
+
+    dataset = simulator.via_layout_from(
+        layout=layout, clocker=parallel_clocker_2d, cti=None
+    )
+
+    assert dataset.data[0, 0:3] == pytest.approx(1.0, 1.0e-4)
+    assert dataset.data[1, 0:3] == pytest.approx(0.998, 1.0e-4)
+
+
 def test__include_read_noise__is_added_after_cti(parallel_clocker_2d, traps_x2, ccd):
     layout = ac.Layout2DCI(
         shape_2d=(3, 3),

--- a/test_autocti/charge_injection/imaging/test_simulator_ci.py
+++ b/test_autocti/charge_injection/imaging/test_simulator_ci.py
@@ -237,6 +237,7 @@ def test__include_stray_light__is_added_before_cti(parallel_clocker_2d, traps_x2
 
 
 def test__include_readout_persistance__is_added_after_cti(parallel_clocker_2d, traps_x2, ccd):
+
     layout = ac.Layout2DCI(
         shape_2d=(3, 3),
         region_list=[(0, 1, 0, 3)],
@@ -247,7 +248,7 @@ def test__include_readout_persistance__is_added_after_cti(parallel_clocker_2d, t
     simulator = ac.SimulatorImagingCI(
         pixel_scales=1.0,
         norm=0.0,
-        stray_light=(-0.002, 1.0),
+        readout_persistance=
     )
 
     dataset = simulator.via_layout_from(

--- a/test_autocti/charge_injection/model/test_result_ci.py
+++ b/test_autocti/charge_injection/model/test_result_ci.py
@@ -8,7 +8,7 @@ from autocti.charge_injection.model.result import ResultImagingCI
 
 
 def test__fits_to_extracted_and_full_datasets_available(
-    imaging_ci_7x7, mask_2d_7x7_unmasked, parallel_clocker_2d, samples_with_result
+    imaging_ci_7x7, mask_2d_7x7_unmasked, parallel_clocker_2d, samples_summary_with_result
 ):
     imaging_ci_full = copy.deepcopy(imaging_ci_7x7)
 
@@ -24,7 +24,7 @@ def test__fits_to_extracted_and_full_datasets_available(
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis,
     )
 
@@ -43,7 +43,7 @@ def test__noise_scaling_map_dict_is_list_of_result__are_correct(
     mask_2d_7x7_unmasked,
     parallel_clocker_2d,
     layout_ci_7x7,
-    samples_with_result,
+    samples_summary_with_result,
     traps_x1,
     ccd,
 ):
@@ -80,11 +80,11 @@ def test__noise_scaling_map_dict_is_list_of_result__are_correct(
     )
 
     fit_analysis = analysis.fit_via_instance_from(
-        instance=samples_with_result.max_log_likelihood()
+        instance=samples_summary_with_result.max_log_likelihood()
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_with_result,
+        samples=samples_summary_with_result,
         analysis=analysis,
     )
 

--- a/test_autocti/charge_injection/model/test_result_ci.py
+++ b/test_autocti/charge_injection/model/test_result_ci.py
@@ -4,7 +4,6 @@ import pytest
 
 import autofit as af
 import autocti as ac
-from autocti.charge_injection.model.result import ResultImagingCI
 
 
 def test__fits_to_extracted_and_full_datasets_available(
@@ -24,7 +23,7 @@ def test__fits_to_extracted_and_full_datasets_available(
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis,
     )
 
@@ -84,7 +83,7 @@ def test__noise_scaling_map_dict_is_list_of_result__are_correct(
     )
 
     result = ac.ResultImagingCI(
-        samples=samples_summary_with_result,
+        samples_summary=samples_summary_with_result,
         analysis=analysis,
     )
 

--- a/test_autocti/conftest.py
+++ b/test_autocti/conftest.py
@@ -229,9 +229,9 @@ def make_fit_ci_7x7():
 from autofit.mapper.model import ModelInstance
 
 
-@pytest.fixture(name="samples_with_result")
-def make_samples_with_result():
-    return fixtures.make_samples_with_result()
+@pytest.fixture(name="samples_summary_with_result")
+def make_samples_summary_with_result():
+    return fixtures.make_samples_summary_with_result()
 
 
 @pytest.fixture(name="analysis_imaging_ci_7x7")


### PR DESCRIPTION
Adds readout persistence to a 2D array of data, typically for simulating charge injection data.

Readout persistence is a feature of CCD detectors (e.g. the Euclid VIS detector), whereby after bright
delta-function like sources (e.g. cosmic rays) are detected, the electronics does not properly reset its bias
level to zero, but instead gets stuck at a higher value (e.g. 3e- to 10e-). Tis persistence appears as rows of
elevated signal in the charge injection data.

If not masked, this elevated signal appears as spikes in the parallel EPER trails, degrading the quality of
CTI calibration.

This class adds readout persistence to a 2D array of data, whereby a number of rows are selected at random and
a value drawn from a Gaussian distribution is added to them. The number of rows and value drawn from the
Gaussian distribution are input as parameters.

This simulation does not pair the location of readout persistence with the location of the location of delta
function like sources, but instead adds it to random rows in the data. This choice is for simplicity and
because all masking techniques do not use the point-source locations to mask readout persistence.
