### PR TITLE
Feature/iterate refactor

### DIFF
--- a/autocti/__init__.py
+++ b/autocti/__init__.py
@@ -54,7 +54,6 @@ from .extract.one_d.fpr import Extract1DFPR
 from .extract.one_d.eper import Extract1DEPER
 from .extract.one_d.master import Extract1DMaster
 from .layout.one_d import Layout1D
-from .dataset_1d.dataset_1d.settings import SettingsDataset1D
 from .dataset_1d.dataset_1d.dataset_1d import Dataset1D
 from .dataset_1d.dataset_1d.simulator import SimulatorDataset1D
 from .dataset_1d.fit import FitDataset1D

--- a/autocti/charge_injection/imaging/settings.py
+++ b/autocti/charge_injection/imaging/settings.py
@@ -5,7 +5,7 @@ import autoarray as aa
 from typing import Tuple
 
 
-class SettingsImagingCI(aa.SettingsImaging):
+class SettingsImagingCI:
     def __init__(
         self,
         parallel_pixels: Tuple[int, int] = None,

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -25,7 +25,6 @@ logger.setLevel(level="INFO")
 
 
 class AnalysisImagingCI(AnalysisCTI):
-
     Result = ResultImagingCI
 
     def __init__(

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -25,6 +25,9 @@ logger.setLevel(level="INFO")
 
 
 class AnalysisImagingCI(AnalysisCTI):
+
+    Result = ResultImagingCI
+
     def __init__(
         self,
         dataset: ImagingCI,
@@ -462,12 +465,3 @@ class AnalysisImagingCI(AnalysisCTI):
                 during_analysis=during_analysis,
                 folder_suffix="_full",
             )
-
-    def make_result(
-        self,
-        samples_summary: af.SamplesSummary,
-        paths: af.AbstractPaths,
-        samples: Optional[af.SamplesPDF] = None,
-        search_internal: Optional[object] = None,
-    ) -> ResultImagingCI:
-        return ResultImagingCI(samples_summary=samples_summary, paths=paths, samples=samples, analysis=self, search_internal=search_internal)

--- a/autocti/dataset_1d/dataset_1d/dataset_1d.py
+++ b/autocti/dataset_1d/dataset_1d/dataset_1d.py
@@ -5,7 +5,6 @@ from typing import Optional, Dict, Union
 import autoarray as aa
 
 from autocti import exc
-from autocti.dataset_1d.dataset_1d.settings import SettingsDataset1D
 from autocti.extract.settings import SettingsExtract
 from autocti.layout.one_d import Layout1D
 
@@ -18,10 +17,9 @@ class Dataset1D(aa.AbstractDataset):
         pre_cti_data: aa.Array1D,
         layout: Layout1D,
         fpr_value: Optional[float] = None,
-        settings: SettingsDataset1D = SettingsDataset1D(),
         settings_dict: Optional[Dict] = None,
     ):
-        super().__init__(data=data, noise_map=noise_map, settings=settings)
+        super().__init__(data=data, noise_map=noise_map)
 
         self.data = data
         self.noise_map = noise_map
@@ -59,9 +57,6 @@ class Dataset1D(aa.AbstractDataset):
             fpr_value=self.fpr_value,
             settings_dict=self.settings_dict,
         )
-
-    def apply_settings(self, settings: SettingsDataset1D) -> "Dataset1D":
-        return self
 
     @classmethod
     def from_fits(

--- a/autocti/dataset_1d/dataset_1d/settings.py
+++ b/autocti/dataset_1d/dataset_1d/settings.py
@@ -1,5 +1,0 @@
-import autoarray as aa
-
-
-class SettingsDataset1D(aa.AbstractSettingsDataset):
-    pass

--- a/autocti/dataset_1d/model/analysis.py
+++ b/autocti/dataset_1d/model/analysis.py
@@ -14,6 +14,9 @@ from autocti.clocker.one_d import Clocker1D
 
 
 class AnalysisDataset1D(AnalysisCTI):
+
+    Result = ResultDataset1D
+
     def __init__(
         self,
         dataset: Dataset1D,
@@ -322,12 +325,3 @@ class AnalysisDataset1D(AnalysisCTI):
                 region_list=region_list,
                 during_analysis=during_analysis,
             )
-
-    def make_result(
-        self,
-        samples_summary: af.SamplesSummary,
-        paths: af.AbstractPaths,
-        samples: Optional[af.SamplesPDF] = None,
-        search_internal: Optional[object] = None,
-    ) -> ResultDataset1D:
-        return ResultDataset1D(samples_summary=samples_summary, paths=paths, samples=samples, analysis=self, search_internal=search_internal)

--- a/autocti/dataset_1d/model/analysis.py
+++ b/autocti/dataset_1d/model/analysis.py
@@ -14,7 +14,6 @@ from autocti.clocker.one_d import Clocker1D
 
 
 class AnalysisDataset1D(AnalysisCTI):
-
     Result = ResultDataset1D
 
     def __init__(

--- a/autocti/model/result.py
+++ b/autocti/model/result.py
@@ -2,11 +2,23 @@ from autofit.non_linear import result
 
 
 class Result(result.Result):
-    def __init__(self, samples_summary, paths=None, samples=None, analysis=None, search_internal = None):
+    def __init__(
+        self,
+        samples_summary,
+        paths=None,
+        samples=None,
+        analysis=None,
+        search_internal=None,
+    ):
         """
         The result of a phase
         """
-        super().__init__(samples_summary=samples_summary, paths=paths, samples=samples, search_internal=search_internal)
+        super().__init__(
+            samples_summary=samples_summary,
+            paths=paths,
+            samples=samples,
+            search_internal=search_internal,
+        )
 
         self.analysis = analysis
 

--- a/test_autocti/aggregator/conftest.py
+++ b/test_autocti/aggregator/conftest.py
@@ -60,7 +60,6 @@ def make_model_1d():
 
 @pytest.fixture(name="samples_1d")
 def make_samples_1d(model_1d):
-
     parameters = [model_1d.prior_count * [1.0], model_1d.prior_count * [10.0]]
 
     sample_list = Sample.from_lists(
@@ -93,7 +92,6 @@ def make_model_2d():
 
 @pytest.fixture(name="samples_2d")
 def make_samples_2d(model_2d):
-
     parameters = [model_2d.prior_count * [1.0], model_2d.prior_count * [10.0]]
 
     sample_list = Sample.from_lists(

--- a/test_autocti/charge_injection/model/test_result_ci.py
+++ b/test_autocti/charge_injection/model/test_result_ci.py
@@ -7,7 +7,10 @@ import autocti as ac
 
 
 def test__fits_to_extracted_and_full_datasets_available(
-    imaging_ci_7x7, mask_2d_7x7_unmasked, parallel_clocker_2d, samples_summary_with_result
+    imaging_ci_7x7,
+    mask_2d_7x7_unmasked,
+    parallel_clocker_2d,
+    samples_summary_with_result,
 ):
     imaging_ci_full = copy.deepcopy(imaging_ci_7x7)
 

--- a/test_autocti/config/general.yaml
+++ b/test_autocti/config/general.yaml
@@ -14,3 +14,5 @@ output:
   model_results_decimal_places: 3
   remove_files: false
   samples_to_csv: true
+test:
+  check_likelihood_function: false  # if True, when a search is resumed the likelihood of a previous sample is recalculated to ensure it is consistent with the previous run.

--- a/test_autocti/config/output.yaml
+++ b/test_autocti/config/output.yaml
@@ -1,0 +1,63 @@
+# Determines whether files saved by the search are output to the hard-disk. This is true both when saving to the
+# directory structure and when saving to database.
+
+# Files can be listed name: bool where the name is the name of the file without a suffix (e.g. model not model.json)
+# and bool is true or false.
+
+# If a given file is not listed then the default value is used.
+
+default: true # If true then files which are not explicitly listed here are output anyway. If false then they are not.
+
+### Samples ###
+
+# The `samples.csv`file contains every sampled value of every free parameter with its log likelihood and weight.
+
+# This file is often large, therefore disabling it can significantly reduce hard-disk space use.
+
+# `samples.csv` is used to perform marginalization, infer model parameter errors and do other analysis of the search
+# chains. Even if output of `samples.csv` is disabled, these tasks are still performed by the fit and output to
+# the `samples_summary.json` file. However, without a `samples.csv` file these types of tasks cannot be performed
+# after the fit is complete, for example via the database.
+
+samples: true
+
+# The `samples.csv` file contains every accepted sampled value of every free parameter with its log likelihood and
+# weight. For certain searches, the majority of samples have a very low weight, which has no numerical impact on the
+# results of the model-fit. However, these samples are still output to the `samples.csv` file, taking up hard-disk space
+# and slowing down analysis of the samples (e.g. via the database).
+
+# The `samples_weight_threshold` below specifies the threshold value of the weight such that samples with a weight
+# below this value are not output to the `samples.csv` file. This can be used to reduce the size of the `samples.csv`
+# file and speed up analysis of the samples.
+
+# Note that for many searches (e.g. MCMC) all samples have equal weight, and thus this threshold has no impact and
+# there is no simple way to save hard-disk space. However, for nested sampling, the majority of samples have a very
+# low weight and this threshold can be used to save hard-disk space.
+
+# Set value to empty (e.g. delete 1.0e-10 below) to disable this feature.
+
+samples_weight_threshold: 1.0e-10
+
+### Search Internal ###
+
+# The search internal folder which contains a saved state of the non-linear search, as a .pickle or .dill file.
+
+# If the entry below is false, the folder is still output during the model-fit, as it is required to resume the fit
+# from where it left off. Therefore, settings `false` below does not impact model-fitting checkpointing and resumption.
+# Instead, the search internal folder is deleted once the fit is completed.
+
+# The search internal folder file is often large, therefore deleting it after a fit is complete can significantly
+# reduce hard-disk space use.
+
+# The search internal representation (e.g. what you can load from the output .pickle file) may have additional
+# quantities specific to the non-linear search that you are interested in inspecting. Deleting the folder means this
+# information is list.
+
+search_internal: false
+
+# Other Files:
+
+covariance: false # `covariance.csv`: The [free parameters x free parameters] covariance matrix.
+data: true # `data.json`: The value of every data point in the data.
+noise_map: true # `noise_map.json`: The value of every RMS noise map value.
+


### PR DESCRIPTION
Oversampling evaluates a light or mass profile with high precision, where an iterative grid may be used which increases the `sub_size` until a threshold precision is met.

This was previously implemented using a `Grid2DIterate` object. However, this led to a lot of code repetition with the `Grid2D` object and an unclear API in terms of how over sampling is performed.

This PR removes the `Grid2DIterate` object and moves the functionality into an `OverSampleIterate` object, which can be passed into a `Grid2D` in order to perform iterative oversampling. 

This also led me to refactor the `dataset` package, removing `Settings` objects which wrapped the `Grid2DIterate` object in awkward ways, cleaning up the code even more!

A follow up PR will add a second `OverSample` object, which performs the normal over sampling which currently occur if the `Grid2D` does not have an `over_sample` object. This has the bold goal of removing the `sub_size` from all `Mask` and data structure objects, would has the potential to make the source code way cleaner. Wish me luck!