### PR TITLE
CTI resurrection Phase 2: autofit sync — factor-graph aggregator port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,10 @@ ecosystem via the CTI resurrection epic
 visualization layer rewritten on the matplotlib **function API**, mirroring
 PyAutoGalaxy: per-domain `plot/*_plots.py` function modules, config-gated
 `model/plotter.py` orchestrators, `autocti/util/plot_utils.py` helpers) are
-complete. Remaining: Phase 2 autofit sync (5 aggregator tests skipped pending
-the `AnalysisFactor`/`FactorGraphModel` port), Phase 3 CI + ecosystem
-plumbing, Phase 4 workspace update, Phase 5 workspace_test rebuild + release.
+complete, as is Phase 2 (autofit sync: multi-dataset fits and the aggregator
+run through `af.AnalysisFactor`/`af.FactorGraphModel`; the test suite has no
+skips). Remaining: Phase 3 CI + ecosystem plumbing, Phase 4 workspace update,
+Phase 5 workspace_test rebuild + release.
 
 ## arcticpy (read before installing)
 

--- a/autocti/aggregator/fit_dataset_1d.py
+++ b/autocti/aggregator/fit_dataset_1d.py
@@ -12,6 +12,30 @@ import autofit as af
 from autocti.aggregator.dataset_1d import _dataset_1d_list_from
 
 
+def _cti_list_from(source, total_datasets: int):
+    """
+    Extract one CTI model per dataset from a model instance.
+
+    A single-analysis instance exposes ``instance.cti`` directly; a factor-graph
+    instance (multi-dataset fit) is an indexed collection with one child
+    instance per factor.
+    """
+    if hasattr(source, "cti"):
+        return [source.cti] * total_datasets
+
+    # A factor-graph instance also carries the FactorGraphModel itself as a
+    # trailing child, so only children with a CTI model are taken.
+    cti_list = [child.cti for child in source if hasattr(child, "cti")]
+
+    if len(cti_list) != total_datasets:
+        raise ValueError(
+            f"The instance contains {len(cti_list)} CTI models but the fit has "
+            f"{total_datasets} datasets."
+        )
+
+    return cti_list
+
+
 def _fit_dataset_1d_list_from(
     fit: af.Fit,
     instance: Optional[af.ModelInstance] = None,
@@ -62,14 +86,14 @@ def _fit_dataset_1d_list_from(
         else:
             clocker_list = fit.child_values(name="clocker")
 
-    if instance is not None:
-        cti = instance.cti
-    else:
-        cti = fit.instance.cti
+    cti_list = _cti_list_from(
+        source=instance if instance is not None else fit.instance,
+        total_datasets=len(dataset_list),
+    )
 
     post_cti_data_list = [
         clocker.add_cti(data=dataset.pre_cti_data, cti=cti)
-        for dataset, clocker in zip(dataset_list, clocker_list)
+        for dataset, clocker, cti in zip(dataset_list, clocker_list, cti_list)
     ]
 
     return [

--- a/autocti/aggregator/fit_imaging_ci.py
+++ b/autocti/aggregator/fit_imaging_ci.py
@@ -13,6 +13,30 @@ from autocti.aggregator.abstract import AggBase
 from autocti.aggregator.imaging_ci import _imaging_ci_list_from
 
 
+def _cti_list_from(source, total_datasets: int):
+    """
+    Extract one CTI model per dataset from a model instance.
+
+    A single-analysis instance exposes ``instance.cti`` directly; a factor-graph
+    instance (multi-dataset fit) is an indexed collection with one child
+    instance per factor.
+    """
+    if hasattr(source, "cti"):
+        return [source.cti] * total_datasets
+
+    # A factor-graph instance also carries the FactorGraphModel itself as a
+    # trailing child, so only children with a CTI model are taken.
+    cti_list = [child.cti for child in source if hasattr(child, "cti")]
+
+    if len(cti_list) != total_datasets:
+        raise ValueError(
+            f"The instance contains {len(cti_list)} CTI models but the fit has "
+            f"{total_datasets} datasets."
+        )
+
+    return cti_list
+
+
 def _fit_imaging_ci_list_from(
     fit: af.Fit,
     instance: Optional[af.ModelInstance] = None,
@@ -63,14 +87,14 @@ def _fit_imaging_ci_list_from(
         else:
             clocker_list = fit.child_values(name="clocker")
 
-    if instance is not None:
-        cti = instance.cti
-    else:
-        cti = fit.instance.cti
+    cti_list = _cti_list_from(
+        source=instance if instance is not None else fit.instance,
+        total_datasets=len(dataset_list),
+    )
 
     post_cti_data_list = [
         clocker.add_cti(data=dataset.pre_cti_data, cti=cti)
-        for dataset, clocker in zip(dataset_list, clocker_list)
+        for dataset, clocker, cti in zip(dataset_list, clocker_list, cti_list)
     ]
 
     return [

--- a/test_autocti/aggregator/conftest.py
+++ b/test_autocti/aggregator/conftest.py
@@ -40,6 +40,31 @@ def aggregator_from(database_file, analysis, model, samples):
 
     clean(database_file=database_file)
 
+    if isinstance(analysis, (list, tuple)):
+        # Analysis summing was removed from PyAutoFit; multi-dataset fits are
+        # expressed as a factor graph with the model shared across factors.
+        # The samples are rebuilt against the global prior model, whose paths
+        # carry per-factor prefixes.
+        factor_list = [
+            af.AnalysisFactor(prior_model=model, analysis=analysis_single)
+            for analysis_single in analysis
+        ]
+        analysis = af.FactorGraphModel(*factor_list)
+        model = analysis.global_prior_model
+
+        sample_list = Sample.from_lists(
+            model=model,
+            parameter_lists=samples.parameter_lists,
+            log_likelihood_list=samples.log_likelihood_list,
+            log_prior_list=[0.0] * len(samples.log_likelihood_list),
+            weight_list=samples.weight_list,
+        )
+        samples = ac.m.MockSamples(
+            model=model,
+            sample_list=sample_list,
+            prior_means=[1.0] * model.prior_count,
+        )
+
     search = ac.m.MockSearch(
         samples=samples, result=ac.m.MockResult(model=model, samples=samples)
     )

--- a/test_autocti/aggregator/test_aggregator_dataset_1d.py
+++ b/test_autocti/aggregator/test_aggregator_dataset_1d.py
@@ -32,11 +32,6 @@ def test__dataset_gen_from__analysis_has_single_dataset(
     clean(database_file=database_file)
 
 
-@pytest.mark.skip(
-    reason="Analysis summing (analysis + analysis) was removed from PyAutoFit in favour "
-    "of AnalysisFactor/FactorGraphModel; these tests are ported in Phase 2 of the CTI "
-    "resurrection epic (PyAutoCTI#82)."
-)
 def test__dataset_gen_from__analysis_has_multi_dataset(
     dataset_1d_7, clocker_1d, samples_1d, model_1d
 ):
@@ -44,7 +39,7 @@ def test__dataset_gen_from__analysis_has_multi_dataset(
 
     agg = aggregator_from(
         database_file=database_file,
-        analysis=analysis + analysis,
+        analysis=[analysis, analysis],
         model=model_1d,
         samples=samples_1d,
     )
@@ -65,11 +60,6 @@ def test__dataset_gen_from__analysis_has_multi_dataset(
     clean(database_file=database_file)
 
 
-@pytest.mark.skip(
-    reason="Analysis summing (analysis + analysis) was removed from PyAutoFit in favour "
-    "of AnalysisFactor/FactorGraphModel; these tests are ported in Phase 2 of the CTI "
-    "resurrection epic (PyAutoCTI#82)."
-)
 def test__dataset_gen_from__analysis_use_dataset_full(
     dataset_1d_7, clocker_1d, samples_1d, model_1d
 ):
@@ -82,7 +72,7 @@ def test__dataset_gen_from__analysis_use_dataset_full(
 
     agg = aggregator_from(
         database_file=database_file,
-        analysis=analysis + analysis,
+        analysis=[analysis, analysis],
         model=model_1d,
         samples=samples_1d,
     )

--- a/test_autocti/aggregator/test_aggregator_fit_imaging_ci.py
+++ b/test_autocti/aggregator/test_aggregator_fit_imaging_ci.py
@@ -34,11 +34,6 @@ def test__fit_imaging_ci_randomly_drawn_via_pdf_gen_from(
     clean(database_file=database_file)
 
 
-@pytest.mark.skip(
-    reason="Analysis summing (analysis + analysis) was removed from PyAutoFit in favour "
-    "of AnalysisFactor/FactorGraphModel; these tests are ported in Phase 2 of the CTI "
-    "resurrection epic (PyAutoCTI#82)."
-)
 def test__fit_imaging_ci_randomly_drawn_via_pdf_gen_from__multi_analysis(
     imaging_ci_7x7, parallel_clocker_2d, samples_2d, model_2d
 ):
@@ -46,7 +41,7 @@ def test__fit_imaging_ci_randomly_drawn_via_pdf_gen_from__multi_analysis(
 
     agg = aggregator_from(
         database_file=database_file,
-        analysis=analysis + analysis,
+        analysis=[analysis, analysis],
         model=model_2d,
         samples=samples_2d,
     )

--- a/test_autocti/aggregator/test_aggregator_imaging_ci.py
+++ b/test_autocti/aggregator/test_aggregator_imaging_ci.py
@@ -32,11 +32,6 @@ def test__dataset_gen_from__analysis_has_single_dataset(
     clean(database_file=database_file)
 
 
-@pytest.mark.skip(
-    reason="Analysis summing (analysis + analysis) was removed from PyAutoFit in favour "
-    "of AnalysisFactor/FactorGraphModel; these tests are ported in Phase 2 of the CTI "
-    "resurrection epic (PyAutoCTI#82)."
-)
 def test__dataset_gen_from__analysis_has_multi_dataset(
     imaging_ci_7x7, parallel_clocker_2d, samples_2d, model_2d
 ):
@@ -44,7 +39,7 @@ def test__dataset_gen_from__analysis_has_multi_dataset(
 
     agg = aggregator_from(
         database_file=database_file,
-        analysis=analysis + analysis,
+        analysis=[analysis, analysis],
         model=model_2d,
         samples=samples_2d,
     )
@@ -66,11 +61,6 @@ def test__dataset_gen_from__analysis_has_multi_dataset(
     clean(database_file=database_file)
 
 
-@pytest.mark.skip(
-    reason="Analysis summing (analysis + analysis) was removed from PyAutoFit in favour "
-    "of AnalysisFactor/FactorGraphModel; these tests are ported in Phase 2 of the CTI "
-    "resurrection epic (PyAutoCTI#82)."
-)
 def test__dataset_gen_from__analysis_use_dataset_full(
     imaging_ci_7x7, parallel_clocker_2d, samples_2d, model_2d
 ):
@@ -85,7 +75,7 @@ def test__dataset_gen_from__analysis_use_dataset_full(
 
     agg = aggregator_from(
         database_file=database_file,
-        analysis=analysis + analysis,
+        analysis=[analysis, analysis],
         model=model_2d,
         samples=samples_2d,
     )


### PR DESCRIPTION
## Summary

Phase 2 of the CTI resurrection epic (#86; Phases 0/1 were #83/#85). PyAutoFit removed analysis summing (`analysis + analysis`) in favour of `af.AnalysisFactor` + `af.FactorGraphModel`; the 5 multi-dataset aggregator tests quarantined in Phase 0 are ported and pass. **The suite now has zero skips**: 271 passed.

## API Changes

- `autocti.aggregator` fit loaders (`fit_dataset_1d`, `fit_imaging_ci`) handle factor-graph model instances: a new `_cti_list_from` helper extracts one CTI model per dataset from either a single-analysis instance or an indexed factor-graph instance (which also carries the `FactorGraphModel` itself as a trailing child), raising loudly on a count mismatch.
- Multi-dataset CTI fits are expressed as `af.FactorGraphModel(*[af.AnalysisFactor(prior_model=model, analysis=a) for a in analyses])` — the same pattern as the autolens workspace `multi` examples. The `visualize_*_combined` path (`in_ascending_fpr_order_from` etc.) is exercised end-to-end by these fits.

## Test Plan

- [x] `python -m pytest test_autocti` — 271 passed, **0 skipped** (5 un-skipped multi-analysis aggregator tests now pass)
- [x] Drift sweep: no remaining removed-autofit idioms in `autocti/`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed
- `autocti/aggregator/fit_dataset_1d.py`, `autocti/aggregator/fit_imaging_ci.py` — `_cti_list_from(source, total_datasets)` replaces the bare `instance.cti` access; single-analysis behavior unchanged.

### Migration
- Before: `search.fit(model=model, analysis=analysis_1 + analysis_2)`
- After: `factor_graph = af.FactorGraphModel(af.AnalysisFactor(prior_model=model, analysis=analysis_1), af.AnalysisFactor(prior_model=model, analysis=analysis_2)); search.fit(model=factor_graph.global_prior_model, analysis=factor_graph)`

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)