### PR TITLE
Rename PyAutoBuild to PyAutoHands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ PyAutoCTI: Charge Transfer Inefficiency Modeling
 .. |Tests| image:: https://github.com/Jammy2211/PyAutoCTI/actions/workflows/main.yml/badge.svg
    :target: https://github.com/Jammy2211/PyAutoCTI/actions
 
-.. |Build| image:: https://github.com/Jammy2211/PyAutoBuild/actions/workflows/release.yml/badge.svg
-   :target: https://github.com/Jammy2211/PyAutoBuild/actions
+.. |Build| image:: https://github.com/PyAutoLabs/PyAutoHands/actions/workflows/release.yml/badge.svg
+   :target: https://github.com/PyAutoLabs/PyAutoHands/actions
 
 .. |code-style| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black


### PR DESCRIPTION
Part of the coordinated **PyAutoBuild → PyAutoHands** repository rename (the Hands organ). Repoints the release-pipeline **Build badge** in `README.rst` to `PyAutoLabs/PyAutoHands`.

**Preserved:** the `autobuild` package/CLI names.

See PyAutoLabs/PyAutoHands#167 for the umbrella rename and `PyAutoHands/MIGRATION.md` for the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsYpZBw74w5g1kAqpWEAiE)_