### PR TITLE
refactor: re-export autoconf config surface from autocti

### DIFF
--- a/autocti/__init__.py
+++ b/autocti/__init__.py
@@ -79,3 +79,34 @@ from autoconf import conf
 conf.instance.register(__file__)
 
 __version__ = "2024.11.13.2"
+
+# ---------------------------------------------------------------------------
+# Public re-export of the autoconf configuration / serialization surface.
+#
+# Workspaces, tutorials and downstream code import these names from the science
+# library (e.g. ``from autolens import conf``) rather than depending on the
+# ``autoconf`` package directly, so the underlying configuration / serialization
+# layer stays an implementation detail of the library.
+# ---------------------------------------------------------------------------
+from autoconf import conf
+from autoconf import jax_wrapper
+from autoconf import fitsable
+from autoconf import setup_colab
+from autoconf import setup_notebook
+from autoconf.conf import with_config
+from autoconf.dictable import from_dict, from_json, to_dict, output_to_json
+from autoconf.fitsable import (
+    output_to_fits,
+    hdu_list_for_output_from,
+    ndarray_via_fits_from,
+    ndarray_via_hdu_from,
+    header_obj_from,
+)
+from autoconf.test_mode import (
+    with_test_mode_segment,
+    skip_visualization,
+    skip_fit_output,
+    skip_checks,
+    is_test_mode,
+    test_mode_level,
+)


### PR DESCRIPTION
## What

Expose the `autoconf` configuration / serialization surface as a deliberate public API of `autocti`, so workspaces and downstream code import `conf` (and `jax_wrapper`, `setup_colab`, `setup_notebook`, `fitsable`, `with_config`, and the `dictable` / `fitsable` / `test_mode` helpers) from the science library rather than depending on the `autoconf` package directly.

## Why

Keeps the config/serialization layer an implementation detail behind the library namespace — the groundwork for hiding `autoconf` (the Nerves organ) from workspace users, and a clean prerequisite for the eventual PyAutoConf → PyAutoNerves rename.

## Validation

CI green on this branch — the `autocti` test suite passes on Python 3.12 & 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_