### PR TITLE
refactor!: depend on and import `autonerves` (renamed from autoconf)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ classes. Heritage: Euclid VIS CTI calibration; also HST ACS
 (`autocti/instruments/acs`).
 
 Dependency direction: autocti may import **autoarray** (data structures),
-**autofit** (model-fitting), and **autoconf** (config). Nothing in the PyAuto
+**autofit** (model-fitting), and **autonerves** (config). Nothing in the PyAuto
 stack imports autocti — it is a leaf like PyAutoLens.
 
 ## Resurrection status (2026-07)
@@ -85,13 +85,13 @@ import autocti as ac
 
 ## Key rules / footguns
 
-- Import direction: autoarray / autofit / autoconf only — never autogalaxy or
+- Import direction: autoarray / autofit / autonerves only — never autogalaxy or
   autolens.
 - Unit tests are numpy-only; there is no JAX in this library (arctic is C++).
 - Slicing an autoarray `Mask2D` returns a plain ndarray — rebuild a `Mask2D`
   with the parent's `pixel_scales` before constructing an `Array2D` from it
   (see `autocti/extract/two_d/abstract.py`).
-- Fits I/O goes through `autoconf.fitsable` (`ndarray_via_fits_from`,
+- Fits I/O goes through `autonerves.fitsable` (`ndarray_via_fits_from`,
   `output_to_fits`, `hdu_list_for_output_from`) — instance `.output_to_fits`
   methods no longer exist on autoarray structures.
 - All files use Unix line endings (LF, `\n`) — never `\r\n`.

--- a/autocti/__init__.py
+++ b/autocti/__init__.py
@@ -1,4 +1,4 @@
-from autoconf.dictable import from_dict, from_json, output_to_json, to_dict
+from autonerves.dictable import from_dict, from_json, output_to_json, to_dict
 
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.layout.region import Region1D
@@ -74,35 +74,35 @@ from . import util
 from . import plot
 from . import mock as m  # noqa
 
-from autoconf import conf
+from autonerves import conf
 
 conf.instance.register(__file__)
 
 __version__ = "2024.11.13.2"
 
 # ---------------------------------------------------------------------------
-# Public re-export of the autoconf configuration / serialization surface.
+# Public re-export of the autonerves configuration / serialization surface.
 #
 # Workspaces, tutorials and downstream code import these names from the science
 # library (e.g. ``from autolens import conf``) rather than depending on the
-# ``autoconf`` package directly, so the underlying configuration / serialization
+# ``autonerves`` package directly, so the underlying configuration / serialization
 # layer stays an implementation detail of the library.
 # ---------------------------------------------------------------------------
-from autoconf import conf
-from autoconf import jax_wrapper
-from autoconf import fitsable
-from autoconf import setup_colab
-from autoconf import setup_notebook
-from autoconf.conf import with_config
-from autoconf.dictable import from_dict, from_json, to_dict, output_to_json
-from autoconf.fitsable import (
+from autonerves import conf
+from autonerves import jax_wrapper
+from autonerves import fitsable
+from autonerves import setup_colab
+from autonerves import setup_notebook
+from autonerves.conf import with_config
+from autonerves.dictable import from_dict, from_json, to_dict, output_to_json
+from autonerves.fitsable import (
     output_to_fits,
     hdu_list_for_output_from,
     ndarray_via_fits_from,
     ndarray_via_hdu_from,
     header_obj_from,
 )
-from autoconf.test_mode import (
+from autonerves.test_mode import (
     with_test_mode_segment,
     skip_visualization,
     skip_fit_output,

--- a/autocti/aggregator/dataset_1d.py
+++ b/autocti/aggregator/dataset_1d.py
@@ -3,7 +3,7 @@ from typing import List
 
 import autofit as af
 import autoarray as aa
-from autoconf.fitsable import ndarray_via_hdu_from
+from autonerves.fitsable import ndarray_via_hdu_from
 
 from autocti.dataset_1d.dataset_1d.dataset_1d import Dataset1D
 

--- a/autocti/aggregator/imaging_ci.py
+++ b/autocti/aggregator/imaging_ci.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import autoarray as aa
-from autoconf.fitsable import ndarray_via_hdu_from
+from autonerves.fitsable import ndarray_via_hdu_from
 import autofit as af
 
 from autocti.charge_injection.imaging.imaging import ImagingCI

--- a/autocti/charge_injection/imaging/imaging.py
+++ b/autocti/charge_injection/imaging/imaging.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, List, Dict, Union
 
 import autoarray as aa
-from autoconf import fitsable
+from autonerves import fitsable
 
 from autocti.charge_injection.imaging.settings import SettingsImagingCI
 from autocti.charge_injection.layout import Layout2DCI

--- a/autocti/charge_injection/model/analysis.py
+++ b/autocti/charge_injection/model/analysis.py
@@ -2,12 +2,12 @@ import numpy as np
 import logging
 from typing import List, Optional
 
-from autoconf import conf
-from autoconf.dictable import to_dict
+from autonerves import conf
+from autonerves.dictable import to_dict
 
 import autoarray as aa
 import autofit as af
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 
 from autocti.charge_injection.imaging.imaging import ImagingCI
 from autocti.charge_injection.fit import FitImagingCI

--- a/autocti/charge_injection/model/visualizer.py
+++ b/autocti/charge_injection/model/visualizer.py
@@ -1,4 +1,4 @@
-from autoconf import conf
+from autonerves import conf
 
 import logging
 

--- a/autocti/charge_injection/plot/fit_ci_plots.py
+++ b/autocti/charge_injection/plot/fit_ci_plots.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import numpy as np
 
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 from autoarray.plot.array import plot_array
 from autoarray.plot.utils import (
     subplots,

--- a/autocti/charge_injection/plot/imaging_ci_plots.py
+++ b/autocti/charge_injection/plot/imaging_ci_plots.py
@@ -1,7 +1,7 @@
 import copy
 from typing import List, Optional
 
-from autoconf import conf
+from autonerves import conf
 
 from autoarray.plot.array import plot_array
 from autoarray.plot.utils import (

--- a/autocti/clocker/abstract.py
+++ b/autocti/clocker/abstract.py
@@ -1,7 +1,7 @@
 from arcticpy import CCD
 from arcticpy import CCDPhase
 
-from autoconf.dictable import from_json, output_to_json
+from autonerves.dictable import from_json, output_to_json
 
 
 class AbstractClocker:

--- a/autocti/dataset_1d/dataset_1d/dataset_1d.py
+++ b/autocti/dataset_1d/dataset_1d/dataset_1d.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, Dict, Union
 
 import autoarray as aa
-from autoconf import fitsable
+from autonerves import fitsable
 
 from autocti import exc
 from autocti.extract.settings import SettingsExtract

--- a/autocti/dataset_1d/model/analysis.py
+++ b/autocti/dataset_1d/model/analysis.py
@@ -1,10 +1,10 @@
 import numpy as np
 from typing import List, Optional
 
-from autoconf.dictable import to_dict
+from autonerves.dictable import to_dict
 
 import autofit as af
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 
 from autocti.dataset_1d.dataset_1d.dataset_1d import Dataset1D
 from autocti.dataset_1d.fit import FitDataset1D

--- a/autocti/dataset_1d/plot/fit_plots.py
+++ b/autocti/dataset_1d/plot/fit_plots.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import numpy as np
 
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 from autoarray.plot.utils import (
     subplots,
     subplot_save,

--- a/autocti/instruments/acs/array_2d.py
+++ b/autocti/instruments/acs/array_2d.py
@@ -11,7 +11,7 @@ from autoarray.structures.arrays import array_2d_util
 from autoarray.layout import layout_util
 
 from autocti.instruments.acs import acs_util
-from autoconf import fitsable
+from autonerves import fitsable
 
 logging.basicConfig()
 logger = logging.getLogger()

--- a/autocti/instruments/acs/image.py
+++ b/autocti/instruments/acs/image.py
@@ -9,7 +9,7 @@ from autocti.instruments.acs.array_2d import Array2DACS
 from autocti.instruments.acs.header import HeaderACS
 
 from autocti.instruments.acs import acs_util
-from autoconf import fitsable
+from autonerves import fitsable
 
 logging.basicConfig()
 logger = logging.getLogger()

--- a/autocti/mask/mask_2d.py
+++ b/autocti/mask/mask_2d.py
@@ -2,7 +2,7 @@ import numpy as np
 from typing import List, Tuple
 
 import autoarray as aa
-from autoconf import fitsable
+from autonerves import fitsable
 
 from autoarray import exc
 

--- a/autocti/model/analysis.py
+++ b/autocti/model/analysis.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union
 
-from autoconf import conf
-from autoconf.dictable import output_to_json
+from autonerves import conf
+from autonerves.dictable import output_to_json
 
 import autoarray as aa
 import autofit as af

--- a/autocti/model/model_util.py
+++ b/autocti/model/model_util.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from autoconf.dictable import from_json
+from autonerves.dictable import from_json
 
 from arcticpy import CCDPhase
 from arcticpy import PixelBounce

--- a/autocti/model/plotter.py
+++ b/autocti/model/plotter.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import List, Union
 
-from autoconf import conf
+from autonerves import conf
 
 
 def setting(section: Union[List[str], str], name: str):

--- a/autocti/model/settings.py
+++ b/autocti/model/settings.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 
 from arcticpy import TrapInstantCapture
 
-from autoconf.dictable import from_json, output_to_json
+from autonerves.dictable import from_json, output_to_json
 
 from autocti import exc
 

--- a/docs/general/configs.rst
+++ b/docs/general/configs.rst
@@ -18,7 +18,7 @@ command (the path to the ``output`` folder where the results of a non-linear sea
 
 .. code-block:: bash
 
-    from autoconf import conf
+    from autonerves import conf
 
     conf.instance.push(
         config_path="path/to/config",

--- a/docs/installation/arctic.rst
+++ b/docs/installation/arctic.rst
@@ -33,7 +33,7 @@ You should get the following text:
     Author-email: Richard Massey <r.j.massey@durham.ac.uk>
     License:
     Location: /mnt/c/Users/Jammy/Code/PyAuto/arctic/python
-    Requires: autoconf, numpy
+    Requires: autonerves, numpy
     Required-by:
 
 If an error is raised when trying to install **arCTIc** you should first try to install it via `pip`:

--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -35,7 +35,7 @@ Next, install the **PyAuto** parent projects via pip:
 
 .. code-block:: bash
 
-   pip install autoconf
+   pip install autonerves
    pip install autofit
    pip install autoarray
 
@@ -102,7 +102,7 @@ Next, install **PyAutoConf** via pip:
 
 .. code-block:: bash
 
-   pip install autoconf
+   pip install autonerves
 
 Next, install the source build dependencies of each project via pip:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 arcticpy==2.6
-autoconf==2024.11.6.1
+autonerves==2024.11.6.1
 numpydoc>=1.0.0
 pyprojroot==0.2.0
 sphinx

--- a/test_autocti/aggregator/conftest.py
+++ b/test_autocti/aggregator/conftest.py
@@ -3,10 +3,10 @@ from os import path
 import os
 import shutil
 
-from autoconf import conf
+from autonerves import conf
 import autofit as af
 import autocti as ac
-from autoconf.conf import with_config
+from autonerves.conf import with_config
 from autofit.non_linear.samples import Sample
 
 

--- a/test_autocti/clocker/test_dict.py
+++ b/test_autocti/clocker/test_dict.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from autoconf.dictable import output_to_json, from_dict, from_json
+from autonerves.dictable import output_to_json, from_dict, from_json
 from autocti import Clocker2D
 
 

--- a/test_autocti/instruments/acs/test_image.py
+++ b/test_autocti/instruments/acs/test_image.py
@@ -1,5 +1,5 @@
 import numpy as np
-from autoconf import fitsable
+from autonerves import fitsable
 from astropy.io import fits
 import copy
 import shutil

--- a/test_autocti/mask/test_mask_2d.py
+++ b/test_autocti/mask/test_mask_2d.py
@@ -3,7 +3,7 @@ from os import path
 import shutil
 
 import numpy as np
-from autoconf import fitsable
+from autonerves import fitsable
 import pytest
 import autocti as ac
 from autocti import exc

--- a/test_autocti/model/test_model_util.py
+++ b/test_autocti/model/test_model_util.py
@@ -2,7 +2,7 @@ import pytest
 from os import path
 
 import autocti as ac
-from autoconf.dictable import output_to_json, from_json
+from autonerves.dictable import output_to_json, from_json
 
 
 def test__trap_all_list():

--- a/test_autocti/model/test_settings_dict.py
+++ b/test_autocti/model/test_settings_dict.py
@@ -2,10 +2,10 @@ import os
 
 import pytest
 
-from autoconf.dictable import from_dict
+from autonerves.dictable import from_dict
 
 import autocti as ac
-from autoconf.dictable import from_dict, output_to_json, from_json
+from autonerves.dictable import from_dict, output_to_json, from_json
 
 
 @pytest.fixture(name="settings_dict")


### PR DESCRIPTION
## What

Switch the `autoconf` dependency to its renamed form **`autonerves`**: pyproject pins and every `import autoconf` / `from autoconf`. Repo-name references (`PyAutoConf`) are unchanged — they flip with the GitHub repo rename.

⚠️ **Breaking / coordinated**: pairs with PyAutoConf#135 and the other library PRs on the **same-named branch**. CI resolves `autonerves` from the same-named PyAutoConf branch. Merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_