### PR TITLE
chore: rename PyAutoConf → PyAutoNerves in docs/prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest t
 
 ## Related repos
 
-- **Source siblings:** PyAutoConf, PyAutoArray, PyAutoFit (upstream).
+- **Source siblings:** PyAutoNerves, PyAutoArray, PyAutoFit (upstream).
 - **autocti_workspace** — runnable examples/tutorials (updated in epic Phase 4).
 - **autocti_workspace_test** — regression scripts + Euclid tvac/temporal
   heritage (rebuilt in epic Phase 5).

--- a/docs/general/configs.rst
+++ b/docs/general/configs.rst
@@ -13,7 +13,7 @@ Setup
 By default, **PyAutoCTI** looks for the config files in a ``config`` folder in the current working directory, which is
 why we run autocti scripts from the ``autocti_workspace`` directory.
 
-The configuration path can also be set manually in a script using the project **PyAutoConf** and the following
+The configuration path can also be set manually in a script using the project **PyAutoNerves** and the following
 command (the path to the ``output`` folder where the results of a non-linear search are stored is also set below):
 
 .. code-block:: bash

--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -35,7 +35,7 @@ Dependencies
 
 **PyAutoCTI** has the following dependencies:
 
-**PyAutoConf** https://github.com/rhayes777/PyAutoConf
+**PyAutoNerves** https://github.com/rhayes777/PyAutoNerves
 
 **PyAutoFit** https://github.com/rhayes777/PyAutoFit
 

--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -98,7 +98,7 @@ First, clone (or fork) all 4 GitHub repositories:
     git clone https://github.com/Jammy2211/PyAutoArray
     git clone https://github.com/Jammy2211/PyAutoCTI
 
-Next, install **PyAutoConf** via pip:
+Next, install **PyAutoNerves** via pip:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## What

Update the "source siblings / related repos" references from PyAutoConf to PyAutoNerves following the GitHub repo rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_