### PR TITLE
fix: delete dead PYAUTOFIT_TEST_MODE fixture in aggregator conftest

### DIFF
--- a/test_autocti/aggregator/conftest.py
+++ b/test_autocti/aggregator/conftest.py
@@ -10,13 +10,6 @@ from autonerves.conf import with_config
 from autofit.non_linear.samples import Sample
 
 
-@pytest.fixture(autouse=True)
-def set_test_mode():
-    os.environ["PYAUTOFIT_TEST_MODE"] = "1"
-    yield
-    del os.environ["PYAUTOFIT_TEST_MODE"]
-
-
 def clean(database_file):
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
 


### PR DESCRIPTION
Closes #95.

## What

Deletes the `autouse` `set_test_mode` fixture in `test_autocti/aggregator/conftest.py`, which set **`PYAUTOFIT_TEST_MODE`** — a variable **nothing in the stack reads**. The canonical knob is `PYAUTO_TEST_MODE` (`PyAutoNerves/autonerves/test_mode.py:14`). The fixture has always been a silent no-op.

## Why delete rather than rename

Renaming it to the live variable looks like the obvious fix, but it is wrong — it makes test mode genuinely take effect, which bypasses sampling, so the aggregator has no samples to iterate and **6 of 13 tests fail**. These tests were written against, and only pass under, normal sampling.

Verified three ways (`pytest test_autocti/aggregator`):

| Variant | Result |
|---|---|
| dead var present (baseline, `main`) | **13 passed** |
| renamed to `PYAUTO_TEST_MODE` | **6 failed**, 7 passed |
| **fixture deleted (this PR)** | **13 passed** |

So deletion is behaviour-preserving and removes the trap outright.

`pytest` and `os` remain used elsewhere in the file, so no import changes.

## Context

`autocti_workspace_test/AGENTS.md:42` and `autocti_assistant/skills/ac_fit_cti_model.md:126` already *documented* that `PYAUTOFIT_TEST_MODE` does not exist. The trap was documented instead of deleted; this deletes it.

Companion docstring fix in PyAutoFit names `PYAUTO_TEST_MODE` explicitly (that prose is what invites the wrong name).