### PR TITLE
feat: require Python 3.12 in PyAutoCTI

### DIFF
--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-**PyAutoCTI** requires Python 3.9 - 3.12 and support Linux and MacOS operating systems (Windows support is targeted in the future).
+**PyAutoCTI** requires Python 3.12 or 3.13 and supports Linux and macOS operating systems (Windows support is targeted in the future).
 
 To use **PyAutoCTI** the c++ library **arCTIc** (https://github.com/jkeger/arctic) must also be installed. Installation instructions for **arCTIc** can be found both
 on its GitHub page and in the **PyAutoCTI** readthedocs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "PyAutoCTI: Charge Transfer Inefficiency Modeling"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 authors = [
     { name = "James Nightingale", email = "James.Nightingale@newcastle.ac.uk" },
     { name = "Richard Massey", email = "r.j.massey@durham.ac.uk" },
@@ -20,9 +20,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]


### PR DESCRIPTION
## Summary
- Require Python 3.12 or newer in PyAutoCTI package metadata.
- Advertise the required 3.12/3.13 support pair and remove 3.9-3.11 classifiers.
- Update the living installation overview while preserving the archival paper and historical traceback.

## API Changes
Packaging compatibility change: new distributions require Python 3.12 or newer and declare Python 3.12/3.13 support. No Python symbols, signatures, or CTI runtime behavior change.
See full details below.

## Test Plan
- [x] Python 3.12.10: `python -m pytest test_autocti/` — 271 passed.
- [x] Python 3.13.13: isolated environment with locally built `arcticpy==2.6` — 271 passed.
- [x] Clean wheel METADATA: `Requires-Python: >=3.12`; only 3.12/3.13 Python classifiers.
- [x] Living support-claim census clean; archival JOSS paper and historical Numba traceback unchanged.
- [x] Smoke n/a: packaging/docs-only change, no runtime API change, and PyAutoCTI is outside the six-workspace smoke matrix.

## Validation checklist (--auto run — plan was not pre-approved)
- Effective level: safe (header: supervised, feature/medium cap: safe → safe)
- Plan: on issue #100, written at start, unmodified since
- Gate: tests 271 passed on 3.12 + 271 passed on 3.13 · smoke n/a (packaging/docs-only) · review CLEAN · Heart YELLOW within launch acknowledgement
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Changed Behaviour
- Distribution metadata now rejects Python below 3.12.
- Supported classifiers are Python 3.12 and 3.13.

### Migration
- Upgrade to Python 3.12 or 3.13 before installing the next PyAutoCTI release.
- Users who must remain on older Python may pin the last compatible unyanked line (`autocti==2024.11.13.2`, to be rechecked at release time).

</details>

Generated by the PyAutoLabs agent workflow.
