### PR TITLE
Bump draft-pdf actions to fleet standard

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -8,14 +8,14 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:
           journal: joss
           paper-path: paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           path: paper/paper.pdf


### PR DESCRIPTION
Part 2 of 4 for PyAutoLabs/PyAutoHands#217: `checkout@v2`→v4, `upload-artifact@v1`→v4 (v1 is past end-of-life — the JOSS draft job was likely already broken). Mechanical version strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)