### PR TITLE
CI: one run per commit (push builds main only)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,17 @@
 name: Tests
 
-on: [push, pull_request]
+# One run per commit: PR events carry the CI; pushes only build main
+# (Heart's ws_ci gate reads main-HEAD conclusions). Superseded runs are
+# cancelled on PR refs only — a cancelled main run would read as red CI
+# (cancelled is in Heart's FAILURE_CONCLUSIONS).
+on:
+  push:
+    branches: [main]
+  pull_request:
 
+concurrency:
+  group: main-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 # Unit tests are defined once, centrally, in PyAutoHeart's reusable workflow
 # (Heart owns all health/readiness checking). This thin caller preserves PR-time
 # gating: the `unittest` job is the required status check on this repo.


### PR DESCRIPTION
Part of PyAutoLabs/PyAutoHeart#130 (fleet CI dedupe — every PR's checks currently run twice).

Mechanical: `on: [push, pull_request]` → `push: branches: [main]` + `pull_request`, plus a `concurrency` group with `cancel-in-progress` on non-main refs only (a cancelled main run would read as red CI to Heart). Post-merge main runs preserved. Trade-off: a branch pushed with no open PR gets no CI until its PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)