### PR TITLE
Export util.dataset (autoarray dataset_util) as ac.util.dataset

### DIFF
--- a/autocti/util/__init__.py
+++ b/autocti/util/__init__.py
@@ -8,6 +8,7 @@ from autoarray.structures.grids import grid_2d_util as grid_2d
 from autoarray.structures.grids import sparse_2d_util as sparse
 from autoarray.layout import layout_util as layout
 from autoarray.fit import fit_util as fit
+from autoarray.util import dataset_util as dataset
 from autocti.model import model_util as model
 from autocti.extract.two_d import extract_2d_util as extract_2d
 from autocti.charge_injection import ci_util as ci


### PR DESCRIPTION
## Summary

Adds the one-line `from autoarray.util import dataset_util as dataset` export to `autocti/util/__init__.py`, mirroring `autolens/util/__init__.py`. This makes `ac.util.dataset.should_simulate` available, which the autocti_workspace auto-simulate guards need to regain `PYAUTO_SMALL_DATASETS=1` force-regeneration (the raw `if not path.exists(dataset_path):` idiom silently loses it).

From PyAutoMind `draft/maintenance/pyauto_cti/autocti_util_dataset_export.md` (found during dataset-bulk leg 6, autocti_workspace#11).

## Verification

- `import autocti as ac; ac.util.dataset.should_simulate` resolves to `autoarray.util.dataset_util.should_simulate` at runtime (Python 3.12, arcticpy 2.6 built from source).
- Full suite: `python -m pytest test_autocti/` — **271 passed, 0 failed, 0 skipped**.
- `git diff origin/main` is exactly this one line.

## Downstream

The companion autocti_workspace PR (same branch name) migrates its 22 raw guards to `ac.util.dataset.should_simulate(dataset_path)` and is gated on this PR by the library-first merge rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vu1p9rcDQGRrYddB6VWcxN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu1p9rcDQGRrYddB6VWcxN)_